### PR TITLE
Significantly improve test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 env:
   matrix:
     - PYTHON_VERSION=2.7
-    - PYTHON_VERSION=3.4
+    - PYTHON_VERSION=3.4 SPHINX_VERSION=1.3
     - PYTHON_VERSION=3.5
   global:
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython pytest-cov"

--- a/docs/automodsumm.rst
+++ b/docs/automodsumm.rst
@@ -16,7 +16,7 @@ the bulk of the work in creating the API tables and pages is done by
 Nevertheless, in most cases, users should not need to call ``automodsumm``
 directly, except if finer control is desired. The syntax of the directive is::
 
-    .. aautomodsumm:: mypackage.mymodule
+    .. automodsumm:: mypackage.mymodule
        <options go here>
 
 .. TODO: the typo above is deliberate, to avoid the directive getting picked

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,8 +29,6 @@ To use this extension, you will need to add the following entry to the
 
     extensions = ['sphinx_automodapi.automodapi']
 
-.. TODO: we could make automodsumm be automatically set up when automodapi is set up
-
 You can then add an ``automodapi`` block anywhere that you want to generate
 documentation for a module::
 
@@ -50,9 +48,20 @@ be installed. To disable the inheritance diagram, you can do::
 The ``automodapi`` directive takes other options that are described in more
 detail in the `User guide`_ below.
 
-.. TODO: disable inheritance diagram by default!
+If you are documenting a module which imports classes from other files, and you
+want to include an inheritance diagram for the classes, you may run into Sphinx
+warnings, because the class may be documented as e.g. ``astropy.table.Table``
+but the class really lives at ``astropy.table.core.Table``. To fix this you can
+make use of the ``'sphinx_automodapi.smart_resolver'`` Sphinx extension, which
+will automatically try and resolve such differences. In this, case, be sure to
+include::
 
-.. TODO: mention about api directory being excluded
+    extensions = ['sphinx_automodapi.automodapi',
+                  'sphinx_automodapi.smart_resolver']
+
+in your ``conf.py`` file.
+..
+.. TODO: disable inheritance diagram by default!
 
 User guide
 ----------

--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -129,6 +129,7 @@ Class Inheritance Diagram
     :private-bases:
     :parts: 1
     {allowedpkgnms}
+    {skip}
 """
 
 _automodapirex = re.compile(r'^(?:\.\.\s+automodapi::\s*)([A-Za-z0-9_.]+)'
@@ -305,10 +306,17 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
 
             if inhdiag and hascls:
                 # add inheritance diagram if any classes are in the module
-                newstrs.append(automod_templ_inh.format(
+                if toskip:
+                    clsskip = ':skip: ' + ','.join(toskip)
+                else:
+                    clsskip = ''
+                diagram_entry = automod_templ_inh.format(
                     modname=modnm,
                     clsinhsechds=h2 * 25,
-                    allowedpkgnms=allowedpkgnms))
+                    allowedpkgnms=allowedpkgnms,
+                    skip=clsskip)
+                diagram_entry = diagram_entry.replace('    \n', '')
+                newstrs.append(diagram_entry)
 
             newstrs.append(spl[grp * 3 + 3])
 

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -166,6 +166,7 @@ class Automodsumm(Autosummary):
             # sphinx doesn't necessarily recognize this fact.  So we just force
             # it internally, and that seems to fix things
             env.temp_data['py:module'] = modname
+            env.ref_context['py:module'] = modname
 
             # can't use super because Sphinx/docutils has trouble return
             # super(Autosummary,self).run()

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -186,6 +186,7 @@ class Automoddiagram(InheritanceDiagram):
 
     option_spec = dict(InheritanceDiagram.option_spec)
     option_spec['allowed-package-names'] = _str_list_converter
+    option_spec['skip'] = _str_list_converter
 
     def run(self):
         try:
@@ -198,8 +199,14 @@ class Automoddiagram(InheritanceDiagram):
             self.warn("Couldn't import module " + self.arguments[0])
             return self.warnings
 
+        # Check if some classes should be skipped
+        skip = self.options.get('skip', [])
+
         clsnms = []
         for n, o in zip(nms, objs):
+
+            if n.split('.')[-1] in skip:
+                continue
 
             if inspect.isclass(o):
                 clsnms.append(n)

--- a/sphinx_automodapi/tests/cases/classes_no_inherit/README.md
+++ b/sphinx_automodapi/tests/cases/classes_no_inherit/README.md
@@ -1,0 +1,1 @@
+A simple case where we are only looking at a module with functions, so no issues with inherited classes etc

--- a/sphinx_automodapi/tests/cases/classes_no_inherit/README.md
+++ b/sphinx_automodapi/tests/cases/classes_no_inherit/README.md
@@ -1,1 +1,1 @@
-A simple case where we are only looking at a module with functions, so no issues with inherited classes etc
+Documenting a module with classes but excluding a class with inheritance

--- a/sphinx_automodapi/tests/cases/classes_no_inherit/input/index.rst
+++ b/sphinx_automodapi/tests/cases/classes_no_inherit/input/index.rst
@@ -1,0 +1,2 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.classes
+   :skip: Spam

--- a/sphinx_automodapi/tests/cases/classes_no_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Egg.rst
+++ b/sphinx_automodapi/tests/cases/classes_no_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Egg.rst
@@ -12,6 +12,14 @@ Egg
 
    
    
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+   
+      ~Egg.weight
+
+   
    
 
    
@@ -28,6 +36,13 @@ Egg
    
 
    
+   
+
+   .. rubric:: Attributes Documentation
+
+   
+   .. autoattribute:: weight
+
    
    
 

--- a/sphinx_automodapi/tests/cases/classes_no_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Egg.rst
+++ b/sphinx_automodapi/tests/cases/classes_no_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Egg.rst
@@ -1,0 +1,44 @@
+
+
+Egg
+==================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.classes
+
+.. autoclass:: Egg
+   :show-inheritance:
+
+   
+
+   
+   
+   
+
+   
+   
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+   
+      ~Egg.buy
+      ~Egg.eat
+
+   
+   
+
+   
+   
+   
+
+   
+   
+
+   .. rubric:: Methods Documentation
+
+   
+   .. automethod:: buy
+   .. automethod:: eat
+
+   
+   

--- a/sphinx_automodapi/tests/cases/classes_no_inherit/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/classes_no_inherit/output/index.rst.automodapi
@@ -1,0 +1,22 @@
+
+sphinx_automodapi.tests.example_module.classes Module
+-----------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.classes
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.classes
+    :classes-only:
+    :toctree: api/
+    :skip: Spam
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module.classes
+    :private-bases:
+    :parts: 1
+    :skip: Spam
+

--- a/sphinx_automodapi/tests/cases/classes_no_inherit/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/classes_no_inherit/output/index.rst.automodsumm
@@ -1,0 +1,7 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.classes
+
+.. autosummary::
+    :toctree: api/
+
+    Egg
+

--- a/sphinx_automodapi/tests/cases/classes_with_inherit/README.md
+++ b/sphinx_automodapi/tests/cases/classes_with_inherit/README.md
@@ -1,0 +1,1 @@
+A simple case where we are only looking at a module with functions, so no issues with inherited classes etc

--- a/sphinx_automodapi/tests/cases/classes_with_inherit/README.md
+++ b/sphinx_automodapi/tests/cases/classes_with_inherit/README.md
@@ -1,1 +1,2 @@
-A simple case where we are only looking at a module with functions, so no issues with inherited classes etc
+Documenting a module with classes including one that inherits a base class
+that isn't in the public API.

--- a/sphinx_automodapi/tests/cases/classes_with_inherit/input/index.rst
+++ b/sphinx_automodapi/tests/cases/classes_with_inherit/input/index.rst
@@ -1,0 +1,1 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.classes

--- a/sphinx_automodapi/tests/cases/classes_with_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Egg.rst
+++ b/sphinx_automodapi/tests/cases/classes_with_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Egg.rst
@@ -12,6 +12,14 @@ Egg
 
    
    
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+   
+      ~Egg.weight
+
+   
    
 
    
@@ -28,6 +36,13 @@ Egg
    
 
    
+   
+
+   .. rubric:: Attributes Documentation
+
+   
+   .. autoattribute:: weight
+
    
    
 

--- a/sphinx_automodapi/tests/cases/classes_with_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Egg.rst
+++ b/sphinx_automodapi/tests/cases/classes_with_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Egg.rst
@@ -1,0 +1,44 @@
+
+
+Egg
+==================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.classes
+
+.. autoclass:: Egg
+   :show-inheritance:
+
+   
+
+   
+   
+   
+
+   
+   
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+   
+      ~Egg.buy
+      ~Egg.eat
+
+   
+   
+
+   
+   
+   
+
+   
+   
+
+   .. rubric:: Methods Documentation
+
+   
+   .. automethod:: buy
+   .. automethod:: eat
+
+   
+   

--- a/sphinx_automodapi/tests/cases/classes_with_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Spam.rst
+++ b/sphinx_automodapi/tests/cases/classes_with_inherit/output/api/sphinx_automodapi.tests.example_module.classes.Spam.rst
@@ -1,0 +1,27 @@
+
+
+Spam
+===================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.classes
+
+.. autoclass:: Spam
+   :show-inheritance:
+
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   

--- a/sphinx_automodapi/tests/cases/classes_with_inherit/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/classes_with_inherit/output/index.rst.automodapi
@@ -1,0 +1,19 @@
+
+sphinx_automodapi.tests.example_module.classes Module
+-----------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.classes
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.classes
+    :classes-only:
+    :toctree: api/
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module.classes
+    :private-bases:
+    :parts: 1

--- a/sphinx_automodapi/tests/cases/classes_with_inherit/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/classes_with_inherit/output/index.rst.automodsumm
@@ -1,0 +1,8 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.classes
+
+.. autosummary::
+    :toctree: api/
+
+    Spam
+    Egg
+

--- a/sphinx_automodapi/tests/cases/func_headings/README.md
+++ b/sphinx_automodapi/tests/cases/func_headings/README.md
@@ -1,0 +1,1 @@
+A simple case where we are only looking at a module with functions, so no issues with inherited classes etc

--- a/sphinx_automodapi/tests/cases/func_headings/README.md
+++ b/sphinx_automodapi/tests/cases/func_headings/README.md
@@ -1,1 +1,1 @@
-A simple case where we are only looking at a module with functions, so no issues with inherited classes etc
+Documenting a module with functions, and customizing the heading symbols

--- a/sphinx_automodapi/tests/cases/func_headings/input/index.rst
+++ b/sphinx_automodapi/tests/cases/func_headings/input/index.rst
@@ -1,0 +1,2 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.functions
+   :headings: *&^

--- a/sphinx_automodapi/tests/cases/func_headings/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
+++ b/sphinx_automodapi/tests/cases/func_headings/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
@@ -1,0 +1,8 @@
+
+
+add
+====================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/func_headings/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
+++ b/sphinx_automodapi/tests/cases/func_headings/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
@@ -1,0 +1,8 @@
+
+
+multiply
+=========================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: multiply

--- a/sphinx_automodapi/tests/cases/func_headings/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/func_headings/output/index.rst.automodapi
@@ -1,0 +1,12 @@
+
+sphinx_automodapi.tests.example_module.functions Module
+*******************************************************
+
+.. automodule:: sphinx_automodapi.tests.example_module.functions
+
+Functions
+&&&&&&&&&
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.functions
+    :functions-only:
+    :toctree: api/

--- a/sphinx_automodapi/tests/cases/func_headings/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_headings/output/index.rst.automodsumm
@@ -1,0 +1,8 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autosummary::
+    :toctree: api/
+
+    add
+    multiply
+

--- a/sphinx_automodapi/tests/cases/func_noheading/README.md
+++ b/sphinx_automodapi/tests/cases/func_noheading/README.md
@@ -1,0 +1,1 @@
+A simple case where we are only looking at a module with functions, so no issues with inherited classes etc

--- a/sphinx_automodapi/tests/cases/func_noheading/README.md
+++ b/sphinx_automodapi/tests/cases/func_noheading/README.md
@@ -1,1 +1,1 @@
-A simple case where we are only looking at a module with functions, so no issues with inherited classes etc
+Documenting a module with functions, and disabling the top-level headings

--- a/sphinx_automodapi/tests/cases/func_noheading/input/index.rst
+++ b/sphinx_automodapi/tests/cases/func_noheading/input/index.rst
@@ -1,0 +1,2 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.functions
+   :no-heading:

--- a/sphinx_automodapi/tests/cases/func_noheading/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
+++ b/sphinx_automodapi/tests/cases/func_noheading/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
@@ -1,0 +1,8 @@
+
+
+add
+====================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/func_noheading/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
+++ b/sphinx_automodapi/tests/cases/func_noheading/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
@@ -1,0 +1,8 @@
+
+
+multiply
+=========================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: multiply

--- a/sphinx_automodapi/tests/cases/func_noheading/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/func_noheading/output/index.rst.automodapi
@@ -1,0 +1,8 @@
+.. automodule:: sphinx_automodapi.tests.example_module.functions
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.functions
+    :functions-only:
+    :toctree: api/

--- a/sphinx_automodapi/tests/cases/func_noheading/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_noheading/output/index.rst.automodsumm
@@ -1,0 +1,8 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autosummary::
+    :toctree: api/
+
+    add
+    multiply
+

--- a/sphinx_automodapi/tests/cases/func_nomaindocstring/README.md
+++ b/sphinx_automodapi/tests/cases/func_nomaindocstring/README.md
@@ -1,0 +1,1 @@
+A simple case where we are only looking at a module with functions, so no issues with inherited classes etc

--- a/sphinx_automodapi/tests/cases/func_nomaindocstring/README.md
+++ b/sphinx_automodapi/tests/cases/func_nomaindocstring/README.md
@@ -1,1 +1,1 @@
-A simple case where we are only looking at a module with functions, so no issues with inherited classes etc
+Documenting a module with functions, excluding the module docstring

--- a/sphinx_automodapi/tests/cases/func_nomaindocstring/input/index.rst
+++ b/sphinx_automodapi/tests/cases/func_nomaindocstring/input/index.rst
@@ -1,0 +1,2 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.functions
+   :no-main-docstr:

--- a/sphinx_automodapi/tests/cases/func_nomaindocstring/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
+++ b/sphinx_automodapi/tests/cases/func_nomaindocstring/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
@@ -1,0 +1,8 @@
+
+
+add
+====================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/func_nomaindocstring/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
+++ b/sphinx_automodapi/tests/cases/func_nomaindocstring/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
@@ -1,0 +1,8 @@
+
+
+multiply
+=========================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: multiply

--- a/sphinx_automodapi/tests/cases/func_nomaindocstring/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/func_nomaindocstring/output/index.rst.automodapi
@@ -1,0 +1,12 @@
+
+sphinx_automodapi.tests.example_module.functions Module
+-------------------------------------------------------
+
+
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.functions
+    :functions-only:
+    :toctree: api/

--- a/sphinx_automodapi/tests/cases/func_nomaindocstring/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_nomaindocstring/output/index.rst.automodsumm
@@ -1,0 +1,8 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autosummary::
+    :toctree: api/
+
+    add
+    multiply
+

--- a/sphinx_automodapi/tests/cases/func_simple/README.md
+++ b/sphinx_automodapi/tests/cases/func_simple/README.md
@@ -1,1 +1,1 @@
-A simple case where we are only looking at a module with functions, so no issues with inherited classes etc
+Documenting a module with functions

--- a/sphinx_automodapi/tests/cases/func_simple/README.md
+++ b/sphinx_automodapi/tests/cases/func_simple/README.md
@@ -1,0 +1,1 @@
+A simple case where we are only looking at a module with functions, so no issues with inherited classes etc

--- a/sphinx_automodapi/tests/cases/func_simple/input/index.rst
+++ b/sphinx_automodapi/tests/cases/func_simple/input/index.rst
@@ -1,0 +1,1 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.functions

--- a/sphinx_automodapi/tests/cases/func_simple/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
+++ b/sphinx_automodapi/tests/cases/func_simple/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
@@ -1,0 +1,8 @@
+
+
+add
+====================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/func_simple/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
+++ b/sphinx_automodapi/tests/cases/func_simple/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
@@ -1,0 +1,8 @@
+
+
+multiply
+=========================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: multiply

--- a/sphinx_automodapi/tests/cases/func_simple/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/func_simple/output/index.rst.automodapi
@@ -1,0 +1,12 @@
+
+sphinx_automodapi.tests.example_module.functions Module
+-------------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.functions
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.functions
+    :functions-only:
+    :toctree: api/

--- a/sphinx_automodapi/tests/cases/func_simple/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_simple/output/index.rst.automodsumm
@@ -5,4 +5,3 @@
 
     add
     multiply
-

--- a/sphinx_automodapi/tests/cases/func_simple/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_simple/output/index.rst.automodsumm
@@ -1,0 +1,8 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autosummary::
+    :toctree: api/
+
+    add
+    multiply
+

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/README.md
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/README.md
@@ -1,2 +1,2 @@
-Documenting a module with classes and functions that are imported from
-other files (which therefore requires the smart_resolver)
+Documenting a module with classes and functions that are imported from other
+files, and with an inheritance diagram (which then requires the smart_resolver)

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/README.md
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/README.md
@@ -1,0 +1,1 @@
+A simple case where we are only looking at a module with functions, so no issues with inherited classes etc

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/README.md
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/README.md
@@ -1,1 +1,2 @@
-A simple case where we are only looking at a module with functions, so no issues with inherited classes etc
+Documenting a module with classes and functions that are imported from
+other files (which therefore requires the smart_resolver)

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/input/index.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/input/index.rst
@@ -1,0 +1,1 @@
+.. automodapi:: sphinx_automodapi.tests.example_module

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.Egg.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.Egg.rst
@@ -1,0 +1,44 @@
+
+
+Egg
+==========================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autoclass:: Egg
+   :show-inheritance:
+
+   
+
+   
+   
+   
+
+   
+   
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+   
+      ~Egg.buy
+      ~Egg.eat
+
+   
+   
+
+   
+   
+   
+
+   
+   
+
+   .. rubric:: Methods Documentation
+
+   
+   .. automethod:: buy
+   .. automethod:: eat
+
+   
+   

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.Egg.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.Egg.rst
@@ -12,6 +12,14 @@ Egg
 
    
    
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+   
+      ~Egg.weight
+
+   
    
 
    
@@ -28,6 +36,13 @@ Egg
    
 
    
+   
+
+   .. rubric:: Attributes Documentation
+
+   
+   .. autoattribute:: weight
+
    
    
 

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.Spam.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.Spam.rst
@@ -1,0 +1,27 @@
+
+
+Spam
+===========================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autoclass:: Spam
+   :show-inheritance:
+
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.add.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.add.rst
@@ -1,0 +1,8 @@
+
+
+add
+==========================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.multiply.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/output/api/sphinx_automodapi.tests.example_module.multiply.rst
@@ -1,0 +1,8 @@
+
+
+multiply
+===============================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autofunction:: multiply

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/output/index.rst.automodapi
@@ -1,0 +1,26 @@
+
+sphinx_automodapi.tests.example_module Package
+----------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module
+    :functions-only:
+    :toctree: api/
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module
+    :classes-only:
+    :toctree: api/
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module
+    :private-bases:
+    :parts: 1

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/output/index.rst.automodsumm
@@ -1,0 +1,15 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autosummary::
+    :toctree: api/
+
+    add
+    multiply
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autosummary::
+    :toctree: api/
+
+    Egg
+    Spam
+

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/README.md
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/README.md
@@ -1,0 +1,2 @@
+Documenting a module with classes and functions that are imported from
+other files

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/input/index.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/input/index.rst
@@ -1,0 +1,2 @@
+.. automodapi:: sphinx_automodapi.tests.example_module
+   :no-inheritance-diagram:

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.Egg.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.Egg.rst
@@ -1,0 +1,44 @@
+
+
+Egg
+==========================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autoclass:: Egg
+   :show-inheritance:
+
+   
+
+   
+   
+   
+
+   
+   
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+   
+      ~Egg.buy
+      ~Egg.eat
+
+   
+   
+
+   
+   
+   
+
+   
+   
+
+   .. rubric:: Methods Documentation
+
+   
+   .. automethod:: buy
+   .. automethod:: eat
+
+   
+   

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.Egg.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.Egg.rst
@@ -12,6 +12,14 @@ Egg
 
    
    
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+   
+      ~Egg.weight
+
+   
    
 
    
@@ -28,6 +36,13 @@ Egg
    
 
    
+   
+
+   .. rubric:: Attributes Documentation
+
+   
+   .. autoattribute:: weight
+
    
    
 

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.Spam.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.Spam.rst
@@ -1,0 +1,27 @@
+
+
+Spam
+===========================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autoclass:: Spam
+   :show-inheritance:
+
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.add.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.add.rst
@@ -1,0 +1,8 @@
+
+
+add
+==========================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.multiply.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/api/sphinx_automodapi.tests.example_module.multiply.rst
@@ -1,0 +1,8 @@
+
+
+multiply
+===============================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autofunction:: multiply

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/index.rst.automodapi
@@ -1,0 +1,19 @@
+
+sphinx_automodapi.tests.example_module Package
+----------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module
+    :functions-only:
+    :toctree: api/
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module
+    :classes-only:
+    :toctree: api/

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/index.rst.automodapi
@@ -17,3 +17,4 @@ Classes
 .. automodsumm:: sphinx_automodapi.tests.example_module
     :classes-only:
     :toctree: api/
+

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/index.rst.automodsumm
@@ -1,0 +1,15 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autosummary::
+    :toctree: api/
+
+    add
+    multiply
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autosummary::
+    :toctree: api/
+
+    Egg
+    Spam
+

--- a/sphinx_automodapi/tests/cases/simple/input/index.rst
+++ b/sphinx_automodapi/tests/cases/simple/input/index.rst
@@ -1,0 +1,1 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.functions

--- a/sphinx_automodapi/tests/cases/simple/input/index.rst
+++ b/sphinx_automodapi/tests/cases/simple/input/index.rst
@@ -1,1 +1,0 @@
-.. automodapi:: sphinx_automodapi.tests.example_module.functions

--- a/sphinx_automodapi/tests/cases/simple/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
+++ b/sphinx_automodapi/tests/cases/simple/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
@@ -1,8 +1,0 @@
-
-
-add
-====================================================
-
-.. currentmodule:: sphinx_automodapi.tests.example_module.functions
-
-.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/simple/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
+++ b/sphinx_automodapi/tests/cases/simple/output/api/sphinx_automodapi.tests.example_module.functions.add.rst
@@ -1,0 +1,8 @@
+
+
+add
+====================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/simple/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
+++ b/sphinx_automodapi/tests/cases/simple/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
@@ -1,0 +1,8 @@
+
+
+multiply
+=========================================================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.functions
+
+.. autofunction:: multiply

--- a/sphinx_automodapi/tests/cases/simple/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
+++ b/sphinx_automodapi/tests/cases/simple/output/api/sphinx_automodapi.tests.example_module.functions.multiply.rst
@@ -1,8 +1,0 @@
-
-
-multiply
-=========================================================
-
-.. currentmodule:: sphinx_automodapi.tests.example_module.functions
-
-.. autofunction:: multiply

--- a/sphinx_automodapi/tests/example_module/__init__.py
+++ b/sphinx_automodapi/tests/example_module/__init__.py
@@ -1,0 +1,2 @@
+from .classes import *
+from .functions import *

--- a/sphinx_automodapi/tests/example_module/classes.py
+++ b/sphinx_automodapi/tests/example_module/classes.py
@@ -42,3 +42,10 @@ class Egg(object):
         Buy some MOAR egg.
         """
         pass
+
+    @property
+    def weight(self):
+        """
+        The weight of an egg
+        """
+        return 0

--- a/sphinx_automodapi/tests/example_module/classes.py
+++ b/sphinx_automodapi/tests/example_module/classes.py
@@ -1,4 +1,4 @@
-__all__ = ['Spam']
+__all__ = ['Spam', 'Egg']
 
 
 class BaseSpam(object):
@@ -24,3 +24,21 @@ class Spam(BaseSpam):
     The main spam
     """
     pass
+
+
+class Egg(object):
+    """
+    An egg (no inheritance)
+    """
+
+    def eat(self, time):
+        """
+        Eat some egg in the required time.
+        """
+        pass
+
+    def buy(self, price):
+        """
+        Buy some MOAR egg.
+        """
+        pass

--- a/sphinx_automodapi/tests/example_module/classes.py
+++ b/sphinx_automodapi/tests/example_module/classes.py
@@ -1,0 +1,26 @@
+__all__ = ['Spam']
+
+
+class BaseSpam(object):
+    """
+    Base class for Spam
+    """
+
+    def eat(self, time):
+        """
+        Eat some spam in the required time.
+        """
+        pass
+
+    def buy(self, price):
+        """
+        Buy some MOAR spam.
+        """
+        pass
+
+
+class Spam(BaseSpam):
+    """
+    The main spam
+    """
+    pass

--- a/sphinx_automodapi/tests/example_module/functions.py
+++ b/sphinx_automodapi/tests/example_module/functions.py
@@ -1,0 +1,19 @@
+"""
+A collection of useful functions
+"""
+
+__all__ = ['add', 'multiply']
+
+
+def add(a, b):
+    """
+    Add two numbers
+    """
+    return a + b
+
+
+def multiply(c, d):
+    """
+    Multiply two numbers
+    """
+    return c * d

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -79,11 +79,9 @@ Class Inheritance Diagram
 .. automod-diagram:: sphinx_automodapi.tests.test_automodapi
     :private-bases:
     :parts: 1
-    {empty}
 
 This comes after
-""".format(empty='')
-# the .format is necessary for editors that remove empty-line whitespace
+"""
 
 
 def test_am_replacer_basic():
@@ -194,11 +192,10 @@ Class Inheritance Diagram
 .. automod-diagram:: sphinx_automodapi.tests.test_automodapi
     :private-bases:
     :parts: 1
-    {empty}
 
 
 This comes after
-""".format(empty='')
+"""
 
 
 def test_am_replacer_titleandhdrs():

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -66,7 +66,7 @@ def test_run_full_case(tmpdir, case_dir):
                  'automodapi_writereprocessed': True,
                  'automodsumm_writereprocessed': True})
 
-    if 'toplevel' in case_dir:
+    if os.path.basename(case_dir) == 'mixed_toplevel':
         conf['extensions'].append('sphinx_automodapi.smart_resolver')
 
     write_conf(os.path.join(src_dir, 'conf.py'), conf)

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -78,7 +78,7 @@ def test_run_full_case(tmpdir, case_dir):
 
     try:
         os.chdir(src_dir)
-        status = build_main(argv=('sphinx-build', '-W', '-b', 'html', '.', 'build/_html'))
+        status = build_main(argv=['sphinx-build', '-W', '-b', 'html', '.', 'build/_html'])
     finally:
         os.chdir(start_dir)
 

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -1,0 +1,67 @@
+# The following tests use a plain Python example module that is at
+# sphinx_automodapi.tests.example_module.
+
+# We store different cases in the cases sub-directory of the tests directory
+
+import os
+import glob
+import shutil
+import pytest
+from copy import deepcopy
+from sphinx import build_main
+
+CASES_ROOT = os.path.join(os.path.dirname(__file__), 'cases')
+
+CASES_DIRS = glob.glob(os.path.join(CASES_ROOT, '*'))
+
+
+def write_conf(filename, conf):
+    with open(filename, 'w') as f:
+        for key, value in conf.items():
+            f.write("{0} = {1}\n".format(key, repr(conf[key])))
+
+
+DEFAULT_CONF = {'source_suffix': '.rst',
+                'master_doc': 'index',
+                'nitpicky': True,
+                'extensions': ['sphinx_automodapi.automodapi']}
+
+
+@pytest.mark.parametrize('case_dir', CASES_DIRS)
+def test_run_full_case(tmpdir, case_dir):
+
+    input_dir = os.path.join(case_dir, 'input')
+    output_dir = os.path.join(case_dir, 'output')
+
+    src_dir = tmpdir.mkdir('src').strpath
+
+    conf = deepcopy(DEFAULT_CONF)
+    conf.update({'automodapi_toctreedirnm': 'api',
+                 'automodapi_writereprocessed': True,
+                 'automodsumm_writereprocessed': True})
+
+    write_conf(os.path.join(src_dir, 'conf.py'), conf)
+
+    for input_file in glob.glob(os.path.join(input_dir, '*')):
+        shutil.copy(input_file, os.path.join(src_dir, os.path.basename(input_file)))
+
+    start_dir = os.path.abspath('.')
+
+    try:
+        os.chdir(src_dir)
+        build_main(argv=('sphinx-build', '-b', 'html', '.', 'build/_html'))
+    finally:
+        os.chdir(start_dir)
+
+    # Check that all expected output files are there and match the reference files
+    for root, dirnames, filenames in os.walk(output_dir):
+        for filename in filenames:
+            path_reference = os.path.join(root, filename)
+            path_relative = os.path.relpath(path_reference, output_dir)
+            path_actual = os.path.join(src_dir, path_relative)
+            assert os.path.exists(path_actual)
+            actual = open(path_actual).read()
+            reference = open(path_reference).read()
+            assert actual.strip() == reference.strip()
+            # if actual != reference:
+            #     raise ValueError("Expected:\n\n{0}\n\nGot:\n\n{1}\n".format(reference, actual))

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -94,5 +94,3 @@ def test_run_full_case(tmpdir, case_dir):
             actual = open(path_actual).read()
             reference = open(path_reference).read()
             assert actual.strip() == reference.strip()
-            # if actual != reference:
-            #     raise ValueError("Expected:\n\n{0}\n\nGot:\n\n{1}\n".format(reference, actual))


### PR DESCRIPTION
This involved creating a number of test cases with reference input and output so that we can run the doc build with the input and make sure we get the correct output. This increases the test coverage from 33% to 82%.

In the process, I discovered a couple of small bugs (as one **always** does when increasing test coverage!)

* If ``:no-main_docstr:`` is not specified, this leads to errors when processing autosummary directives because the currentmodule doesn't appear to have an effect. There was a workaround for this based on comments in the code, but I had to add an extra workaround to get it to work for me.

* The inheritance diagram should not show skipped classes, so I've fixed this

@eteq - if we decide to abandon this standalone version, I'll make sure we pull the changes back to astropy-helpers. Feel free to leave comments on this if you like!

Even though this looks like a lot of changes, most are self-contained new files that could easily be copied back to astropy-helpers if needed.

(oops, meant to open this from a branch on my fork)