### PR TITLE
Allow also non-functions/classes to be included in module API summary.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes in sphinx-automodapi
 
 - Introduce a new ``:include-all-objects:`` option to ``automodapi`` that will
   include not just functions and classes in a module, but also all other
-  objects. To help this, introduce a new ``:global-variables-only:`` option for
+  objects. To help this, introduce a new ``:variables-only:`` option for
   ``automodsumm``. [#24]
 
 0.3 (2017-02-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Changes in sphinx-automodapi
 
 - Fix compatibility with Sphinx 1.6 and 1.7. [#22, #23]
 
+- Introduce a new ``:include-all-objects:`` option to ``automodapi`` that will
+  include not just functions and classes in a module, but also all other
+  objects. To help this, introduce a new ``:global-variables-only:`` option for
+  ``automodsumm``. [#24]
+
 0.3 (2017-02-20)
 ----------------
 

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/README.md
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/README.md
@@ -1,0 +1,3 @@
+Documenting a module with classes, functions, and variables that are
+imported from other files, and with an inheritance diagram (which then
+requires the smart_resolver).

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/input/index.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/input/index.rst
@@ -1,0 +1,2 @@
+.. automodapi:: sphinx_automodapi.tests.example_module
+    :include-all-objects:

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.Egg.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.Egg.rst
@@ -1,0 +1,29 @@
+Egg
+===
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autoclass:: Egg
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~Egg.weight
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Egg.buy
+      ~Egg.eat
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: weight
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: buy
+   .. automethod:: eat

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.FUNNY_WALK_STEPS.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.FUNNY_WALK_STEPS.rst
@@ -1,0 +1,6 @@
+FUNNY_WALK_STEPS
+================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autodata:: FUNNY_WALK_STEPS

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.PARROT_STATE.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.PARROT_STATE.rst
@@ -1,0 +1,6 @@
+PARROT_STATE
+============
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autodata:: PARROT_STATE

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.Spam.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.Spam.rst
@@ -1,0 +1,7 @@
+Spam
+====
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autoclass:: Spam
+   :show-inheritance:

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.add.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.add.rst
@@ -1,0 +1,6 @@
+add
+===
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autofunction:: add

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.multiply.rst
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/api/sphinx_automodapi.tests.example_module.multiply.rst
@@ -1,0 +1,6 @@
+multiply
+========
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autofunction:: multiply

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/index.rst.automodapi
@@ -1,0 +1,33 @@
+
+sphinx_automodapi.tests.example_module Package
+----------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module
+    :functions-only:
+    :toctree: api
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module
+    :classes-only:
+    :toctree: api
+
+Variables
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module
+    :variables-only:
+    :toctree: api
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module
+    :private-bases:
+    :parts: 1

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/index.rst.automodsumm
@@ -1,0 +1,21 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autosummary::
+    :toctree: api
+
+    add
+    multiply
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autosummary::
+    :toctree: api
+
+    Egg
+    Spam
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autosummary::
+    :toctree: api
+
+    FUNNY_WALK_STEPS
+    PARROT_STATE

--- a/sphinx_automodapi/tests/cases/variables/README.md
+++ b/sphinx_automodapi/tests/cases/variables/README.md
@@ -1,0 +1,1 @@
+Documenting a module with global variables

--- a/sphinx_automodapi/tests/cases/variables/input/index.rst
+++ b/sphinx_automodapi/tests/cases/variables/input/index.rst
@@ -1,0 +1,2 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.variables
+    :include-all-objects:

--- a/sphinx_automodapi/tests/cases/variables/output/api/sphinx_automodapi.tests.example_module.variables.FUNNY_WALK_STEPS.rst
+++ b/sphinx_automodapi/tests/cases/variables/output/api/sphinx_automodapi.tests.example_module.variables.FUNNY_WALK_STEPS.rst
@@ -1,0 +1,6 @@
+FUNNY_WALK_STEPS
+================
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.variables
+
+.. autodata:: FUNNY_WALK_STEPS

--- a/sphinx_automodapi/tests/cases/variables/output/api/sphinx_automodapi.tests.example_module.variables.PARROT_STATE.rst
+++ b/sphinx_automodapi/tests/cases/variables/output/api/sphinx_automodapi.tests.example_module.variables.PARROT_STATE.rst
@@ -1,0 +1,6 @@
+PARROT_STATE
+============
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.variables
+
+.. autodata:: PARROT_STATE

--- a/sphinx_automodapi/tests/cases/variables/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/variables/output/index.rst.automodapi
@@ -1,0 +1,12 @@
+
+sphinx_automodapi.tests.example_module.variables Module
+-------------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.variables
+
+Variables
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.variables
+    :variables-only:
+    :toctree: api

--- a/sphinx_automodapi/tests/cases/variables/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/variables/output/index.rst.automodsumm
@@ -1,0 +1,7 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.variables
+
+.. autosummary::
+    :toctree: api
+
+    PARROT_STATE
+    FUNNY_WALK_STEPS

--- a/sphinx_automodapi/tests/example_module/__init__.py
+++ b/sphinx_automodapi/tests/example_module/__init__.py
@@ -1,2 +1,3 @@
 from .classes import *
 from .functions import *
+from .variables import *

--- a/sphinx_automodapi/tests/example_module/variables.py
+++ b/sphinx_automodapi/tests/example_module/variables.py
@@ -1,0 +1,24 @@
+"""
+A collection of useful variables.
+"""
+
+__all__ = ['PARROT_STATE', 'FUNNY_WALK_STEPS']
+
+
+PARROT_STATE = 'dead'
+"""The global state of the parrot."""
+
+FUNNY_WALK_STEPS = [['left', 'right'],
+                    ['left', 'jump', 'right', 'jump'],
+                    ['swim']]
+"""List of different possible walk.
+
+Each item contains a list of steps.
+"""
+
+# A variable not in __all__ should not be propagated.
+NOTHING_HAPPENS = 0
+
+# Even if it has a docstring
+REALLY_NOTHING = 1
+"""Really nothing."""

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -70,7 +70,8 @@ def test_run_full_case(tmpdir, case_dir):
                  'automodapi_writereprocessed': True,
                  'automodsumm_writereprocessed': True})
 
-    if os.path.basename(case_dir) == 'mixed_toplevel':
+    if os.path.basename(case_dir) in ('mixed_toplevel',
+                                      'mixed_toplevel_all_objects'):
         conf['extensions'].append('sphinx_automodapi.smart_resolver')
 
     start_dir = os.path.abspath('.')


### PR DESCRIPTION
This is a rebase with renamed arguments of https://github.com/astropy/astropy-helpers/pull/198, since the automodapi routines now seem to live here.