### PR TITLE
Moved setup configuration to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,26 @@
+[metadata]
+name = sphinx-automodapi
+version = attr:sphinx_automodapi.__version__
+description = Sphinx extension for auto-generating API documentation for entire modules
+long_description = file:README.rst
+author = The Astropy Developers
+author_email = astropy.team@gmail.com
+license = BSD 3-Clause License
+url = http://astropy.org
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 3
+    Operating System :: OS Independent
+    License :: OSI Approved :: BSD License
+
+[options]
+zip_safe = False
+packages = find:
+install_requires = sphinx>=1.3
+
+[options.package_data]
+sphinx_automodapi = templates/*/*.rst
+sphinx_automodapi.tests = cases/*/*.*, cases/*/*/*.*, cases/*/*/*/*.*

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,14 @@
 #!/usr/bin/env python
+
+import sys
+import setuptools
+from distutils.version import LooseVersion
 from setuptools import setup
+
+# Setuptools 30.3.0 or later is needed for setup.cfg options to be used
+if LooseVersion(setuptools.__version__) < LooseVersion('30.3.0'):
+    sys.stderr.write("ERROR: sphinx-automodapi requires setuptools 30.3.0 or "
+                     "later (found {0})".format(setuptools.__version__))
+    sys.exit(1)
+
 setup()

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,3 @@
 #!/usr/bin/env python
-
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 from setuptools import setup
-
-with open('README.rst') as infile:
-    long_description = infile.read()
-
-from sphinx_automodapi import __version__
-
-setup(
-    name='sphinx-automodapi',
-    version=__version__,
-    description='Sphinx extension for auto-generating API documentation for entire modules',
-    long_description=long_description,
-    author='The Astropy Developers',
-    author_email='astropy.team@gmail.com',
-    license='BSD',
-    url='http://astropy.org',
-    zip_safe=False,
-    install_requires=['sphinx>=1.3'],
-    packages=['sphinx_automodapi', 'sphinx_automodapi.tests', 'sphinx_automodapi.tests.example_module'],
-    package_data={
-        'sphinx_automodapi': ['templates/*/*.rst'],
-        'sphinx_automodapi.tests': [
-            'cases/*/*.*', 'cases/*/*/*.*', 'cases/*/*/*/*.*']},
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
-        'Operating System :: OS Independent',
-        'License :: OSI Approved :: BSD License',
-    ]
-)
+setup()


### PR DESCRIPTION
Looks like everything can be done through setup.cfg here! As for astropy core, this means that setuptools 30 or later is required (although most users will probably install from wheels so it probably won't matter). Should we include a version check for setuptools in setup.py?