### PR TITLE
Fix smart resolver when intersphinx inventory doesn't include py:class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changes in sphinx-automodapi
 - Added a global configuration option ``automodapi_inheritance_diagram`` to
   control whether inheritance diagrams are shown by default. [#75]
 
+- Fix bug with smart_resolver when intersphinx inventory doesn't include
+  any py:class entries. [#76]
+
 0.10 (2019-01-09)
 -----------------
 

--- a/sphinx_automodapi/smart_resolver.py
+++ b/sphinx_automodapi/smart_resolver.py
@@ -73,7 +73,7 @@ def missing_reference_handler(app, env, node, contnode):
                 if (reftarget not in mapping and
                         prefix in inventory):
 
-                    if reftarget in inventory[prefix]['py:class']:
+                    if 'py:class' in inventory[prefix] and reftarget in inventory[prefix]['py:class']:
                         newtarget = inventory[prefix]['py:class'][reftarget][2]
                         if not node['refexplicit'] and \
                                 '~' not in node.rawsource:


### PR DESCRIPTION
Ran into this with the ipywidgets intersphinx inventory