### PR TITLE
Fix remaining instances of app.warn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes in sphinx-automodapi
 0.12 (unreleased)
 -----------------
 
-- No changes yet.
+- Fixed compatibility with Sphinx 2.0 and later. [#86]
 
 
 0.11 (2019-05-29)

--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -5,18 +5,18 @@ Miscellaneous enhancements to help autodoc along.
 import inspect
 import sys
 import types
-import sphinx
-from distutils.version import LooseVersion
 
 from sphinx.ext.autodoc import AttributeDocumenter, ModuleDocumenter
 from sphinx.util.inspect import isdescriptor
+
+from .utils import SPHINX_LT_15
+
+__all__ = []
 
 if sys.version_info[0] == 3:
     class_types = (type,)
 else:
     class_types = (type, types.ClassType)
-
-SPHINX_LT_15 = (LooseVersion(sphinx.__version__) < LooseVersion('1.5'))
 
 MethodDescriptorType = type(type.__subclasses__)
 

--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -99,19 +99,15 @@ import io
 import os
 import re
 import sys
-from distutils.version import LooseVersion
 
-from sphinx import __version__
+from .utils import SPHINX_LT_16, find_mod_objs
 
-from .utils import find_mod_objs
-
-SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
+__all__ = []
 
 if sys.version_info[0] == 3:
     text_type = str
 else:
-    text_type = unicode
-
+    text_type = unicode  # noqa
 
 automod_templ_modheader = """
 {modname} {pkgormod}

--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -99,8 +99,14 @@ import io
 import os
 import re
 import sys
+from distutils.version import LooseVersion
+
+from sphinx import __version__
 
 from .utils import find_mod_objs
+
+SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
+SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
 
 if sys.version_info[0] == 3:
     text_type = str
@@ -198,6 +204,13 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
         sphinx markup.
     """
 
+    if SPHINX_LT_16:
+        warn = app.warn
+    else:
+        from sphinx.util import logging
+        logger = logging.getLogger(__name__)
+        warn = logger.warning
+
     spl = _automodapirex.split(sourcestr)
     if len(spl) > 1:  # automodsumm is in this document
 
@@ -270,19 +283,20 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 onlylocals = allowedpkgnms
 
             # get the two heading chars
+            hds = hds.strip()
             if len(hds) < 2:
                 msg = 'Not enough headings (got {0}, need 2), using default -^'
                 if warnings:
-                    app.warn(msg.format(len(hds)), location)
+                    warn(msg.format(len(hds)), location)
                 hds = '-^'
-            h1, h2 = hds.lstrip()[:2]
+            h1, h2 = hds[:2]
 
             # tell sphinx that the remaining args are invalid.
             if len(unknownops) > 0 and app is not None:
                 opsstrs = ','.join(unknownops)
                 msg = 'Found additional options ' + opsstrs + ' in automodapi.'
                 if warnings:
-                    app.warn(msg, location)
+                    warn(msg, location)
 
             ispkg, hascls, hasfuncs, hasother = _mod_info(
                 modnm, toskip, onlylocals=onlylocals)

--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -106,7 +106,6 @@ from sphinx import __version__
 from .utils import find_mod_objs
 
 SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
-SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
 
 if sys.version_info[0] == 3:
     text_type = str

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -443,8 +443,6 @@ def generate_automodsumm_docs(lines, srcfn, app=None, suffix='.rst',
         info = logger.info
         warn = logger.warning
 
-    # info('[automodsumm] generating automodsumm for: ' + srcfn)
-
     # Create our own templating environment - here we use Astropy's
     # templates rather than the default autosummary templates, in order to
     # allow docstrings to be shown for methods.

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -88,20 +88,16 @@ import inspect
 import os
 import re
 import io
-from distutils.version import LooseVersion
 
-from sphinx import __version__
 from sphinx.ext.autosummary import Autosummary
 from sphinx.ext.inheritance_diagram import InheritanceDiagram
 from docutils.parsers.rst.directives import flag
 
-from .utils import find_mod_objs, cleanup_whitespace
+from .utils import (SPHINX_LT_16, SPHINX_LT_17, find_mod_objs,
+                    cleanup_whitespace)
 
 __all__ = ['Automoddiagram', 'Automodsumm', 'automodsumm_to_autosummary_lines',
            'generate_automodsumm_docs', 'process_automodsumm_generation']
-
-SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
-SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
 
 
 def _str_list_converter(argument):
@@ -274,6 +270,7 @@ def process_automodsumm_generation(app):
                 lines, sfn, app=app, builder=app.builder,
                 suffix=suffix, base_path=app.srcdir,
                 inherited_members=app.config.automodsumm_inherited_members)
+
 
 # _automodsummrex = re.compile(r'^(\s*)\.\. automodsumm::\s*([A-Za-z0-9_.]+)\s*'
 #                              r'\n\1(\s*)(\S|$)', re.MULTILINE)

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -313,6 +313,13 @@ def automodsumm_to_autosummary_lines(fn, app):
 
     """
 
+    if SPHINX_LT_16:
+        warn = app.warn
+    else:
+        from sphinx.util import logging
+        logger = logging.getLogger(__name__)
+        warn = logger.warning
+
     fullfn = os.path.join(app.builder.env.srcdir, fn)
 
     with io.open(fullfn, encoding='utf8') as fr:
@@ -376,7 +383,7 @@ def automodsumm_to_autosummary_lines(fn, app):
             msg = ('Defined more than one of functions-only, classes-only, '
                    'and variables-only.  Skipping this directive.')
             lnnum = sum([spl[j].count('\n') for j in range(i * 5 + 1)])
-            app.warn('[automodsumm]' + msg, (fn, lnnum))
+            warn('[automodsumm] ' + msg, (fn, lnnum))
             continue
 
         # Use the currentmodule directive so we can just put the local names

--- a/sphinx_automodapi/tests/__init__.py
+++ b/sphinx_automodapi/tests/__init__.py
@@ -45,10 +45,9 @@ def cython_testpackage(tmpdir, request):
         )
     """.format(os.path.dirname(sphinx_automodapi.__path__[0]))))
 
-    test_pkg.chdir()
     # Build the Cython module in a subprocess; otherwise strange things can
     # happen with Cython's global module state
-    sp.call([sys.executable, 'setup.py', 'build_ext', '--inplace'])
+    sp.call([sys.executable, 'setup.py', 'build_ext', '--inplace'], cwd=test_pkg.strpath)
 
     sys.path.insert(0, str(test_pkg))
     import apyhtest_eva.unit02

--- a/sphinx_automodapi/tests/__init__.py
+++ b/sphinx_automodapi/tests/__init__.py
@@ -50,7 +50,7 @@ def cython_testpackage(tmpdir, request):
     sp.call([sys.executable, 'setup.py', 'build_ext', '--inplace'], cwd=test_pkg.strpath)
 
     sys.path.insert(0, str(test_pkg))
-    import apyhtest_eva.unit02
+    import apyhtest_eva.unit02  # noqa
 
     def cleanup(test_pkg=test_pkg):
         for modname in ['apyhtest_eva', 'apyhtest_eva.unit02']:

--- a/sphinx_automodapi/tests/cases/func_headings/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_headings/output/index.rst.automodsumm
@@ -4,4 +4,5 @@
     :toctree: api
 
     add
+    subtract
     multiply

--- a/sphinx_automodapi/tests/cases/func_noheading/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_noheading/output/index.rst.automodsumm
@@ -4,4 +4,5 @@
     :toctree: api
 
     add
+    subtract
     multiply

--- a/sphinx_automodapi/tests/cases/func_nomaindocstring/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_nomaindocstring/output/index.rst.automodsumm
@@ -4,4 +4,5 @@
     :toctree: api
 
     add
+    subtract
     multiply

--- a/sphinx_automodapi/tests/cases/func_simple/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/func_simple/output/index.rst.automodsumm
@@ -4,4 +4,5 @@
     :toctree: api
 
     add
+    subtract
     multiply

--- a/sphinx_automodapi/tests/cases/mixed_toplevel/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel/output/index.rst.automodsumm
@@ -5,6 +5,7 @@
 
     add
     multiply
+    subtract
 .. currentmodule:: sphinx_automodapi.tests.example_module
 
 .. autosummary::

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_all_objects/output/index.rst.automodsumm
@@ -5,6 +5,7 @@
 
     add
     multiply
+    subtract
 .. currentmodule:: sphinx_automodapi.tests.example_module
 
 .. autosummary::

--- a/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/mixed_toplevel_nodiagram/output/index.rst.automodsumm
@@ -5,6 +5,7 @@
 
     add
     multiply
+    subtract
 .. currentmodule:: sphinx_automodapi.tests.example_module
 
 .. autosummary::

--- a/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodsumm
@@ -4,4 +4,5 @@
     :toctree: api
 
     add
+    subtract
     multiply

--- a/sphinx_automodapi/tests/cases/source_dir/output/src/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/source_dir/output/src/index.rst.automodsumm
@@ -4,4 +4,5 @@
     :toctree: api
 
     add
+    subtract
     multiply

--- a/sphinx_automodapi/tests/example_module/__init__.py
+++ b/sphinx_automodapi/tests/example_module/__init__.py
@@ -1,3 +1,3 @@
-from .classes import *
-from .functions import *
-from .variables import *
+from .classes import *  # noqa
+from .functions import *  # noqa
+from .variables import *  # noqa

--- a/sphinx_automodapi/tests/example_module/functions.py
+++ b/sphinx_automodapi/tests/example_module/functions.py
@@ -2,7 +2,7 @@
 A collection of useful functions
 """
 
-__all__ = ['add', 'multiply']
+__all__ = ['add', 'subtract', 'multiply']
 
 
 def add(a, b):
@@ -10,6 +10,13 @@ def add(a, b):
     Add two numbers
     """
     return a + b
+
+
+def subtract(a, b):
+    """
+    Subtract two numbers
+    """
+    return a - b
 
 
 def multiply(c, d):

--- a/sphinx_automodapi/tests/example_module/mixed.py
+++ b/sphinx_automodapi/tests/example_module/mixed.py
@@ -22,4 +22,3 @@ class MixedSpam(object):
         Eat special spam in the required time.
         """
         pass
-

--- a/sphinx_automodapi/tests/example_module/mixed.py
+++ b/sphinx_automodapi/tests/example_module/mixed.py
@@ -1,0 +1,25 @@
+"""
+A collection of useful classes and functions
+"""
+
+__all__ = ['add', 'MixedSpam']
+
+
+def add(a, b):
+    """
+    Add two numbers
+    """
+    return a + b
+
+
+class MixedSpam(object):
+    """
+    Special spam
+    """
+
+    def eat(self, time):
+        """
+        Eat special spam in the required time.
+        """
+        pass
+

--- a/sphinx_automodapi/tests/helpers.py
+++ b/sphinx_automodapi/tests/helpers.py
@@ -5,15 +5,19 @@ import os
 import sys
 from copy import deepcopy
 
-from .test_cases import write_conf, SPHINX_LT_17, build_main
+from ..utils import SPHINX_LT_17
 from . import cython_testpackage  # noqa
 
-__all__ = ['run_sphinx_in_tmpdir']
+__all__ = ['build_main', 'write_conf', 'run_sphinx_in_tmpdir']
+
+if SPHINX_LT_17:
+    from sphinx import build_main
+else:
+    from sphinx.cmd.build import build_main
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{0}/'.format(sys.version_info[0]), None)
     }
-
 
 DEFAULT_CONF = {'source_suffix': '.rst',
                 'master_doc': 'index',
@@ -25,6 +29,12 @@ DEFAULT_CONF = {'source_suffix': '.rst',
                 'automodapi_writereprocessed': True,
                 'automodapi_inheritance_diagram': True,
                 'automodsumm_writereprocessed': True}
+
+
+def write_conf(filename, conf):
+    with open(filename, 'w') as f:
+        for key, value in conf.items():
+            f.write("{0} = {1}\n".format(key, repr(conf[key])))
 
 
 def run_sphinx_in_tmpdir(tmpdir, additional_conf={}, expect_error=False):

--- a/sphinx_automodapi/tests/helpers.py
+++ b/sphinx_automodapi/tests/helpers.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import os
+import sys
+from copy import deepcopy
+
+from .test_cases import write_conf, SPHINX_LT_17, build_main
+from . import cython_testpackage  # noqa
+
+__all__ = ['run_sphinx_in_tmpdir']
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/{0}/'.format(sys.version_info[0]), None)
+    }
+
+
+DEFAULT_CONF = {'source_suffix': '.rst',
+                'master_doc': 'index',
+                'nitpicky': True,
+                'extensions': ['sphinx.ext.intersphinx', 'sphinx_automodapi.automodapi'],
+                'suppress_warnings': ['app.add_directive', 'app.add_node'],
+                'intersphinx_mapping': intersphinx_mapping,
+                'automodapi_toctreedirnm': 'api',
+                'automodapi_writereprocessed': True,
+                'automodapi_inheritance_diagram': True,
+                'automodsumm_writereprocessed': True}
+
+
+def run_sphinx_in_tmpdir(tmpdir, additional_conf={}, expect_error=False):
+
+    start_dir = os.path.abspath('.')
+
+    conf = deepcopy(DEFAULT_CONF)
+    conf.update(additional_conf)
+
+    write_conf(tmpdir.join('conf.py').strpath, conf)
+
+    argv = ['-W', '-b', 'html', '.', '_build/html']
+    if SPHINX_LT_17:
+        # As of Sphinx 1.7, the first argument is now no longer ignored
+        argv.insert(0, 'sphinx-build')
+
+    try:
+        os.chdir(tmpdir.strpath)
+        status = build_main(argv=argv)
+    finally:
+        os.chdir(start_dir)
+
+    if expect_error:
+        assert status != 0
+    else:
+        assert status == 0

--- a/sphinx_automodapi/tests/test_autodoc_enhancements.py
+++ b/sphinx_automodapi/tests/test_autodoc_enhancements.py
@@ -14,6 +14,7 @@ class Meta(type):
     def foo(cls):
         return 'foo'
 
+
 if sys.version_info[0] < 3:
     exec(dedent("""
         class MyClass(object):

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -203,12 +203,6 @@ def test_am_replacer_titleandhdrs(tmpdir):
     assert result == am_replacer_titleandhdrs_expected
 
 
-EXPECTED_HEADINGS_STDERR = """
-Warning, treated as error:
-Not enough headings (got 1, need 2), using default -^
-"""
-
-
 def test_am_replacer_titleandhdrs_invalid(tmpdir, capsys):
     """
     Tests replacing an ".. automodapi::" entry with title-setting and header
@@ -224,7 +218,7 @@ def test_am_replacer_titleandhdrs_invalid(tmpdir, capsys):
     run_sphinx_in_tmpdir(tmpdir, expect_error=True)
 
     stdout, stderr = capsys.readouterr()
-    assert stderr.strip() == EXPECTED_HEADINGS_STDERR.strip()
+    assert "Not enough headings (got 1, need 2), using default -^" in stderr
 
 
 am_replacer_nomain_str = """
@@ -330,11 +324,6 @@ This comes before
 This comes after
 """
 
-EXPECTED_INVALID_STDERR = """
-Warning, treated as error:
-Found additional options invalid-option in automodapi.
-"""
-
 
 def test_am_replacer_invalidop(tmpdir, capsys):
     """
@@ -347,7 +336,7 @@ def test_am_replacer_invalidop(tmpdir, capsys):
     run_sphinx_in_tmpdir(tmpdir, expect_error=True)
 
     stdout, stderr = capsys.readouterr()
-    assert stderr.strip() == EXPECTED_INVALID_STDERR.strip()
+    assert "Found additional options invalid-option in automodapi." in stderr
 
 
 am_replacer_cython_str = """

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -2,8 +2,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import sys
+from copy import copy
 
 import pytest
+from docutils.parsers.rst import directives, roles
 
 from . import cython_testpackage  # noqa
 from .helpers import run_sphinx_in_tmpdir
@@ -14,6 +16,18 @@ else:
     io_open = open
 
 pytest.importorskip('sphinx')  # skips these tests if sphinx not present
+
+
+def setup_function(func):
+    # This can be replaced with the docutils_namespace context manager once
+    # it is in a stable release of Sphinx
+    func._directives = copy(directives._directives)
+    func._roles = copy(roles._roles)
+
+
+def teardown_function(func):
+    directives._directives = func._directives
+    roles._roles = func._roles
 
 
 am_replacer_str = """

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import sys
+
 import pytest
 
 from . import cython_testpackage  # noqa
 from .helpers import run_sphinx_in_tmpdir
+
+if sys.version_info[0] == 2:
+    from io import open as io_open
+else:
+    io_open = open
 
 pytest.importorskip('sphinx')  # skips these tests if sphinx not present
 
@@ -63,7 +70,7 @@ def test_am_replacer_basic(tmpdir):
 
     run_sphinx_in_tmpdir(tmpdir)
 
-    with open(tmpdir.join('index.rst.automodapi')) as f:
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
         result = f.read()
 
     assert result == am_replacer_basic_expected
@@ -85,7 +92,7 @@ def test_am_replacer_writereprocessed(tmpdir, writereprocessed):
     Tests the automodapi_writereprocessed option
     """
 
-    with open(tmpdir.join('index.rst').strpath, 'w') as f:
+    with io_open(tmpdir.join('index.rst').strpath, 'w', encoding='utf-8') as f:
         f.write(am_replacer_repr_str.format(options=''))
 
     run_sphinx_in_tmpdir(tmpdir, additional_conf={'automodapi_writereprocessed': writereprocessed})
@@ -135,7 +142,7 @@ def test_am_replacer_noinh(tmpdir):
 
     run_sphinx_in_tmpdir(tmpdir)
 
-    with open(tmpdir.join('index.rst.automodapi')) as f:
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
         result = f.read()
 
     assert result == am_replacer_noinh_expected
@@ -190,7 +197,7 @@ def test_am_replacer_titleandhdrs(tmpdir):
 
     run_sphinx_in_tmpdir(tmpdir)
 
-    with open(tmpdir.join('index.rst.automodapi')) as f:
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
         result = f.read()
 
     assert result == am_replacer_titleandhdrs_expected
@@ -260,7 +267,7 @@ def test_am_replacer_nomain(tmpdir):
 
     run_sphinx_in_tmpdir(tmpdir)
 
-    with open(tmpdir.join('index.rst.automodapi')) as f:
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
         result = f.read()
 
     assert result == am_replacer_nomain_expected
@@ -308,7 +315,7 @@ def test_am_replacer_skip(tmpdir):
 
     run_sphinx_in_tmpdir(tmpdir)
 
-    with open(tmpdir.join('index.rst.automodapi')) as f:
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
         result = f.read()
 
     assert result == am_replacer_skip_expected
@@ -382,7 +389,7 @@ def test_am_replacer_cython(tmpdir, cython_testpackage):  # noqa
 
     run_sphinx_in_tmpdir(tmpdir)
 
-    with open(tmpdir.join('index.rst.automodapi')) as f:
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
         result = f.read()
 
     assert result == am_replacer_cython_expected

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -15,8 +15,6 @@ if sys.version_info[0] == 2:
 else:
     io_open = open
 
-pytest.importorskip('sphinx')  # skips these tests if sphinx not present
-
 
 def setup_function(func):
     # This can be replaced with the docutils_namespace context manager once

--- a/sphinx_automodapi/tests/test_automodsumm.py
+++ b/sphinx_automodapi/tests/test_automodsumm.py
@@ -38,11 +38,10 @@ MixedSpam
 
 def write_api_files_to_tmpdir(tmpdir):
     apidir = tmpdir.mkdir('api')
-    with open(apidir.join('sphinx_automodapi.tests.example_module.mixed.add.rst'), 'w') as f:
+    with open(apidir.join('sphinx_automodapi.tests.example_module.mixed.add.rst').strpath, 'w') as f:
         f.write(ADD_RST)
-    with open(apidir.join('sphinx_automodapi.tests.example_module.mixed.MixedSpam.rst'), 'w') as f:
+    with open(apidir.join('sphinx_automodapi.tests.example_module.mixed.MixedSpam.rst').strpath, 'w') as f:
         f.write(MIXEDSPAM_RST)
-
 
 
 ams_to_asmry_str = """
@@ -74,7 +73,7 @@ def test_ams_to_asmry(tmpdir):
 
     run_sphinx_in_tmpdir(tmpdir)
 
-    with open(tmpdir.join('index.rst.automodsumm')) as f:
+    with open(tmpdir.join('index.rst.automodsumm').strpath) as f:
         result = f.read()
 
     assert result == ams_to_asmry_expected
@@ -138,12 +137,12 @@ def test_ams_cython(tmpdir, cython_testpackage):  # noqa
         f.write(ams_cython_str)
 
     apidir = tmpdir.mkdir('api')
-    with open(apidir.join('apyhtest_eva.unit02.pilot.rst'), 'w') as f:
+    with open(apidir.join('apyhtest_eva.unit02.pilot.rst').strpath, 'w') as f:
         f.write(PILOT_RST)
 
     run_sphinx_in_tmpdir(tmpdir)
 
-    with open(tmpdir.join('index.rst.automodsumm')) as f:
+    with open(tmpdir.join('index.rst.automodsumm').strpath) as f:
         result = f.read()
 
     assert result == ams_cython_expected

--- a/sphinx_automodapi/tests/test_automodsumm.py
+++ b/sphinx_automodapi/tests/test_automodsumm.py
@@ -1,17 +1,12 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from copy import copy
 
-import pytest
 from docutils.parsers.rst import directives, roles
 
 from . import cython_testpackage  # noqa
 from .helpers import run_sphinx_in_tmpdir
-
-pytest.importorskip('sphinx')  # skips these tests if sphinx not present
 
 
 def setup_function(func):
@@ -110,7 +105,6 @@ def test_too_many_options(tmpdir, capsys):
     stdout, stderr = capsys.readouterr()
     assert ("[automodsumm] Defined more than one of functions-only, "
             "classes-only, and variables-only.  Skipping this directive." in stderr)
-
 
 
 PILOT_RST = """

--- a/sphinx_automodapi/tests/test_automodsumm.py
+++ b/sphinx_automodapi/tests/test_automodsumm.py
@@ -3,12 +3,28 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from copy import copy
+
 import pytest
+from docutils.parsers.rst import directives, roles
 
 from . import cython_testpackage  # noqa
 from .helpers import run_sphinx_in_tmpdir
 
 pytest.importorskip('sphinx')  # skips these tests if sphinx not present
+
+
+def setup_function(func):
+    # This can be replaced with the docutils_namespace context manager once
+    # it is in a stable release of Sphinx
+    func._directives = copy(directives._directives)
+    func._roles = copy(roles._roles)
+
+
+def teardown_function(func):
+    directives._directives = func._directives
+    roles._roles = func._roles
+
 
 # nosignatures
 

--- a/sphinx_automodapi/tests/test_automodsumm.py
+++ b/sphinx_automodapi/tests/test_automodsumm.py
@@ -79,11 +79,6 @@ def test_ams_to_asmry(tmpdir):
     assert result == ams_to_asmry_expected
 
 
-EXPECTED_OPTIONS_STDERR = """
-Warning, treated as error:
-[automodsumm] Defined more than one of functions-only, classes-only, and variables-only.  Skipping this directive.
-"""
-
 def test_too_many_options(tmpdir, capsys):
 
     ops = ['', ':classes-only:', ':functions-only:']
@@ -97,7 +92,8 @@ def test_too_many_options(tmpdir, capsys):
     run_sphinx_in_tmpdir(tmpdir, expect_error=True)
 
     stdout, stderr = capsys.readouterr()
-    assert stderr.strip() == EXPECTED_OPTIONS_STDERR.strip()
+    assert ("[automodsumm] Defined more than one of functions-only, "
+            "classes-only, and variables-only.  Skipping this directive." in stderr)
 
 
 

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -9,22 +9,15 @@ import sys
 import glob
 import shutil
 from itertools import product
-from distutils.version import LooseVersion
 
 import pytest
 
 from copy import deepcopy, copy
-from sphinx import __version__
 from sphinx.util.osutil import ensuredir
 from docutils.parsers.rst import directives, roles
 
-SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
-SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
-
-if SPHINX_LT_17:
-    from sphinx import build_main
-else:
-    from sphinx.cmd.build import build_main
+from ..utils import SPHINX_LT_16, SPHINX_LT_17
+from .helpers import build_main, write_conf
 
 CASES_ROOT = os.path.join(os.path.dirname(__file__), 'cases')
 
@@ -34,12 +27,6 @@ if SPHINX_LT_16 or os.environ.get('TRAVIS_OS_NAME', None) == 'osx':
     PARALLEL = {False}
 else:
     PARALLEL = {False, True}
-
-
-def write_conf(filename, conf):
-    with open(filename, 'w') as f:
-        for key, value in conf.items():
-            f.write("{0} = {1}\n".format(key, repr(conf[key])))
 
 
 intersphinx_mapping = {

--- a/sphinx_automodapi/utils.py
+++ b/sphinx_automodapi/utils.py
@@ -3,9 +3,17 @@ import sys
 import re
 import os
 from warnings import warn
+from distutils.version import LooseVersion
 
+from sphinx import __version__
 from sphinx.ext.autosummary.generate import find_autosummary_in_docstring
 
+__all__ = ['SPHINX_LT_16', 'SPHINX_LT_17', 'cleanup_whitespace',
+           'find_mod_objs', 'find_autosummary_in_lines_for_automodsumm']
+
+SPHINX_LT_15 = LooseVersion(__version__) < LooseVersion('1.5')
+SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
+SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
 
 if sys.version_info[0] >= 3:
     def iteritems(dictionary):


### PR DESCRIPTION
The issue in https://github.com/astropy/sphinx-automodapi/issues/80 was not caught previously because the way we ran some of the tests was to create a fake application class, which still had warn and info. Rather than try to adjust this to the latest Sphinx API, I changed these tests to properly use sphinx rather than 'fake' classes which will be more future proof.

Fixes https://github.com/astropy/sphinx-automodapi/issues/80