### PR TITLE
Update sphinx req to 1.7 and add version "policy"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes in sphinx-automodapi
 -----------------
 
 - Fixed compatibility with Sphinx 2.0 and later. [#86]
+- The minimum sphinx version is now 1.7. [#88]
 
 
 0.11 (2019-05-29)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,8 @@ The extension is also available through conda package management system. It can 
 
     conda install -c astropy sphinx-automodapi
 
+
+
 .. _quickstart:
 
 Quick start
@@ -69,3 +71,11 @@ User guide
 
    automodapi.rst
    automodsumm.rst
+
+Dependency Version Guidelines
+-----------------------------
+
+As a general guideline, automodapi dependencies (at the time of writing, just
+Sphinx) aim to maintain compatibility with versions <= 2 years old. Dependencies
+may be newer, however, if specific features become important to help automodapi
+work better or be more maintainable.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ standalone package that can be used for any project.
 Installation
 ------------
 
-This extension requires Sphinx 1.3 or later, and can be installed with::
+This extension requires Sphinx 1.7 or later, and can be installed with::
 
     pip install sphinx-automodapi
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 zip_safe = False
 packages = find:
 install_requires =
-    sphinx>=1.3
+    sphinx>=1.7
 
 [options.extras_require]
 test =

--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -74,8 +74,6 @@ def type_object_attrgetter(obj, attr, *defargs):
 def setup(app):
     # Must have the autodoc extension set up first so we can override it
     app.setup_extension('sphinx.ext.autodoc')
-    # Need to import this too since it re-registers all the documenter types
-    # =_=
 
     app.add_autodoc_attrgetter(type, type_object_attrgetter)
 

--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -100,7 +100,9 @@ import os
 import re
 import sys
 
-from .utils import SPHINX_LT_16, find_mod_objs
+from sphinx.util import logging
+
+from .utils import find_mod_objs
 
 __all__ = []
 
@@ -199,12 +201,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
         sphinx markup.
     """
 
-    if SPHINX_LT_16:
-        warn = app.warn
-    else:
-        from sphinx.util import logging
-        logger = logging.getLogger(__name__)
-        warn = logger.warning
+    logger = logging.getLogger(__name__)
 
     spl = _automodapirex.split(sourcestr)
     if len(spl) > 1:  # automodsumm is in this document
@@ -282,7 +279,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
             if len(hds) < 2:
                 msg = 'Not enough headings (got {0}, need 2), using default -^'
                 if warnings:
-                    warn(msg.format(len(hds)), location)
+                    logger.warning(msg.format(len(hds)), location)
                 hds = '-^'
             h1, h2 = hds[:2]
 
@@ -291,7 +288,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 opsstrs = ','.join(unknownops)
                 msg = 'Found additional options ' + opsstrs + ' in automodapi.'
                 if warnings:
-                    warn(msg, location)
+                    logger.warning(msg, location)
 
             ispkg, hascls, hasfuncs, hasother = _mod_info(
                 modnm, toskip, onlylocals=onlylocals)

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -144,8 +144,8 @@ class Automodsumm(Autosummary):
             clsonly = 'classes-only' in self.options
             varonly = 'variables-only' in self.options
             if [clsonly, funconly, varonly].count(True) > 1:
-                self.warn('more than one of functions-only, classes-only, '
-                             'or variables-only defined. Ignoring.')
+                self.warn('more than one of "functions-only", "classes-only", '
+                          'or "variables-only" defined. Ignoring.')
                 clsonly = funconly = varonly = False
 
             skipnames = []

--- a/sphinx_automodapi/tests/helpers.py
+++ b/sphinx_automodapi/tests/helpers.py
@@ -5,15 +5,12 @@ import os
 import sys
 from copy import deepcopy
 
-from ..utils import SPHINX_LT_17
+from sphinx.cmd.build import build_main
+
 from . import cython_testpackage  # noqa
 
-__all__ = ['build_main', 'write_conf', 'run_sphinx_in_tmpdir']
+__all__ = ['write_conf', 'run_sphinx_in_tmpdir']
 
-if SPHINX_LT_17:
-    from sphinx import build_main
-else:
-    from sphinx.cmd.build import build_main
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{0}/'.format(sys.version_info[0]), None)
@@ -47,9 +44,6 @@ def run_sphinx_in_tmpdir(tmpdir, additional_conf={}, expect_error=False):
     write_conf(tmpdir.join('conf.py').strpath, conf)
 
     argv = ['-W', '-b', 'html', '.', '_build/html']
-    if SPHINX_LT_17:
-        # As of Sphinx 1.7, the first argument is now no longer ignored
-        argv.insert(0, 'sphinx-build')
 
     try:
         os.chdir(tmpdir.strpath)

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -16,17 +16,13 @@ from copy import deepcopy, copy
 from sphinx.util.osutil import ensuredir
 from docutils.parsers.rst import directives, roles
 
-from ..utils import SPHINX_LT_16, SPHINX_LT_17
 from .helpers import build_main, write_conf
 
 CASES_ROOT = os.path.join(os.path.dirname(__file__), 'cases')
 
 CASES_DIRS = glob.glob(os.path.join(CASES_ROOT, '*'))
 
-if SPHINX_LT_16 or os.environ.get('TRAVIS_OS_NAME', None) == 'osx':
-    PARALLEL = {False}
-else:
-    PARALLEL = {False, True}
+PARALLEL = {False, True}
 
 
 intersphinx_mapping = {
@@ -99,9 +95,6 @@ def test_run_full_case(tmpdir, case_dir, parallel):
     argv = ['-W', '-b', 'html', src_dir, '_build/html']
     if parallel:
         argv.insert(0, '-j 4')
-    if SPHINX_LT_17:
-        # As of Sphinx 1.7, the first argument is now no longer ignored
-        argv.insert(0, 'sphinx-build')
 
     try:
         os.chdir(docs_dir)

--- a/sphinx_automodapi/utils.py
+++ b/sphinx_automodapi/utils.py
@@ -8,12 +8,8 @@ from distutils.version import LooseVersion
 from sphinx import __version__
 from sphinx.ext.autosummary.generate import find_autosummary_in_docstring
 
-__all__ = ['SPHINX_LT_16', 'SPHINX_LT_17', 'cleanup_whitespace',
+__all__ = ['cleanup_whitespace',
            'find_mod_objs', 'find_autosummary_in_lines_for_automodsumm']
-
-SPHINX_LT_15 = LooseVersion(__version__) < LooseVersion('1.5')
-SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
-SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
 
 if sys.version_info[0] >= 3:
     def iteritems(dictionary):

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,7 @@ envlist =
     py37-test
     py27-test-clocale
     py37-test-clocale
-    py27-test-sphinx13
-    py35-test-sphinx14
-    py35-test-sphinx15
-    py36-test-sphinx16
+    py27-test-sphinx17
     py36-test-sphinx17
     py37-test-sphinx18
     py37-test-sphinx20
@@ -18,10 +15,6 @@ requires = pip >= 18.0
 [testenv]
 changedir = .tmp/{envname}
 deps =
-    sphinx13: sphinx==1.3.6
-    sphinx14: sphinx==1.4.9
-    sphinx15: sphinx==1.5.6
-    sphinx16: sphinx==1.6.7
     sphinx17: sphinx==1.7.9
     sphinx18: sphinx==1.8.5
     sphinx20: sphinx==2.0.1


### PR DESCRIPTION
This closes #85 by updating the sphinx dependecy to 1.7 as discussed further in that issue.

One thing I realized I wasn't sure about: when I dropped all the older tox environments, there was nothing left for py2.7, so I added one back in that does py2.7 and sphinx 1.7, which seems sensible.  But I'm not 100% sure that one will work, so @astrofrog you might want to check that.