### PR TITLE
Add automodsumm_ignore_emptydoc global option and flags

### DIFF
--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -54,8 +54,15 @@ It accepts the following options:
         The global sphinx configuration option
         ``automodsumm_inherited_members`` decides if members that a class
         inherits from a base class are included in the generated
-        documentation. The option ``:inherited-members:`` or ``:no-inherited-members:``
-        allows the user to overrride the global setting.
+        documentation. The flags ``:inherited-members:`` or ``:no-inherited-members:``
+        allow the user to overrride the global setting.
+
+    * ``:ignore-emptydoc:`` or ``:no-ignore-emptydoc:``
+        The global sphinx configuration option ``automodsumm_ignore_emptydoc``
+        decides if functions, classes, and class methods with empty
+        ``__doc__`` attributes are included in the generated documentation. The flags
+        ``:ignore-emptydoc:`` or ``:no-ignore-emptydoc:`` allow the user to override
+        the global setting.
 
 
 This extension also adds four sphinx configuration options:
@@ -241,7 +248,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
 
             # look for actual options
             unknownops = []
-            inherited_members = None
+            inherited_members = ignore_emptydoc = None
             for opname, args in _automodapiargsrex.findall(spl[grp * 3 + 2]):
                 if opname == 'skip':
                     toskip.append(args.strip())
@@ -261,6 +268,10 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                     inherited_members = True
                 elif opname == 'no-inherited-members':
                     inherited_members = False
+                elif opname == 'ignore-emptydoc':
+                    ignore_emptydoc = True
+                elif opname == 'no-ignore-emptydoc':
+                    ignore_emptydoc = False
                 elif opname == 'include-all-objects':
                     allowothers = True
                 else:
@@ -322,6 +333,10 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 clsfuncoptions.append(':skip: ' + ','.join(toskip))
             if allowedpkgnms:
                 clsfuncoptions.append(allowedpkgnms)
+            if ignore_emptydoc is True:
+                clsfuncoptions.append(':ignore-emptydoc:')
+            if ignore_emptydoc is False:
+                clsfuncoptions.append(':no-ignore-emptydoc:')
             if hascls:  # This makes no sense unless there are classes.
                 if inherited_members is True:
                     clsfuncoptions.append(':inherited-members:')

--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -59,10 +59,9 @@ It accepts the following options:
 
     * ``:ignore-emptydoc:`` or ``:no-ignore-emptydoc:``
         The global sphinx configuration option ``automodsumm_ignore_emptydoc``
-        decides if functions, classes, and class methods with empty
-        ``__doc__`` attributes are included in the generated documentation. The flags
-        ``:ignore-emptydoc:`` or ``:no-ignore-emptydoc:`` allow the user to override
-        the global setting.
+        decides if class methods with empty ``__doc__`` attributes are included
+        in the generated documentation. The flags ``:ignore-emptydoc:`` or
+        ``:no-ignore-emptydoc:`` allow the user to override the global setting.
 
 
 This extension also adds four sphinx configuration options:
@@ -333,15 +332,15 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 clsfuncoptions.append(':skip: ' + ','.join(toskip))
             if allowedpkgnms:
                 clsfuncoptions.append(allowedpkgnms)
-            if ignore_emptydoc is True:
-                clsfuncoptions.append(':ignore-emptydoc:')
-            if ignore_emptydoc is False:
-                clsfuncoptions.append(':no-ignore-emptydoc:')
             if hascls:  # This makes no sense unless there are classes.
                 if inherited_members is True:
                     clsfuncoptions.append(':inherited-members:')
                 if inherited_members is False:
                     clsfuncoptions.append(':no-inherited-members:')
+                if ignore_emptydoc is True:
+                    clsfuncoptions.append(':ignore-emptydoc:')
+                if ignore_emptydoc is False:
+                    clsfuncoptions.append(':no-ignore-emptydoc:')
             clsfuncoptionstr = '\n    '.join(clsfuncoptions)
 
             if hasfuncs:

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -48,10 +48,9 @@ options:
 
     * ``:ignore-emptydoc:`` or ``:no-ignore-emptydoc:``
         The global sphinx configuration option ``automodsumm_ignore_emptydoc``
-        decides if functions, classes, and class methods with empty
-        ``__doc__`` attributes are included in the generated documentation. The flags
-        ``:ignore-emptydoc:`` or ``:no-ignore-emptydoc:`` allows overrriding this
-        global setting.
+        decides if class methods with empty ``__doc__`` attributes are included
+        in the generated documentation. The flags ``:ignore-emptydoc:`` or
+        ``:no-ignore-emptydoc:`` allows overrriding this global setting.
 
 This extension also adds three sphinx configuration options:
 
@@ -70,11 +69,10 @@ This extension also adds three sphinx configuration options:
     ``False``.
 
 * ``automodsumm_ignore_emptydoc``
-    Should be a bool, and if ``True``, will cause `automodsumm`_ to ignore
-    functions, classes, and class methods with empty ``__doc__`` attributes.
-    This value can be overridden for any particular automodsumm directive by including
-    the ``:ignore-emptydoc:`` or ``:no-ignore-emptydoc:`` options. Defaults to
-    ``False``.
+    Should be a bool, and if ``True``, will cause `automodsumm`_ to ignore class
+    methods with empty ``__doc__`` attributes. This value can be overridden for any
+    particular automodsumm directive by including the ``:ignore-emptydoc:`` or
+    ``:no-ignore-emptydoc:`` options. Defaults to ``False``.
 
 .. _sphinx.ext.autosummary: http://sphinx-doc.org/latest/ext/autosummary.html
 .. _autosummary: http://sphinx-doc.org/latest/ext/autosummary.html#directive-autosummary
@@ -577,7 +575,7 @@ def generate_automodsumm_docs(lines, srcfn, app=None, suffix='.rst',
                         continue
                     if (
                         ignore_emptydoc
-                        and documenter.objtype in ('method', 'class', 'function')
+                        and documenter.objtype == 'method'
                         and not getattr(safe_getattr(obj, name), '__doc__', '')
                     ):
                         continue


### PR DESCRIPTION
Implements item 1 from #91. This adds and documents the `automodsumm_ignore_emptydoc` flag and `:ignore-emptydoc:` and `:no-ignore-emptydoc:` options, which can be thought of as an expansion of `automodsumm_inherited_methods`, `:inherited-methods:`, and `:no-inherited-methods:`.

These options are used to ignore "public" (i.e. name does not start with `_`) class methods with empty `__doc__` attributes. This can be used to let developers override public methods or classes from external libraries, but suppress documentation of those overrides.  Developers may want to leave out the docstring from an overridden public method so that when users query `help(cls.method)`, they get the original, rich documentation from the external library, and they do not have to reproduce the external library documentation in their bare-bones override function.

This may be a bit niche for ProPlot but I think it's a pretty harmless addition, and it of course defaults to `False`.