### PR TITLE
Fix allowed names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes in sphinx-automodapi
 0.13 (unreleased)
 -----------------
 
-- No changes yet.
+- Fixed implementation of ``allowed-package-names`` option (which did
+  not work at all). [#111]
 
 0.12 (2019-08-15)
 -----------------

--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -256,7 +256,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 elif opname == 'no-heading':
                     top_head = False
                 elif opname == 'allowed-package-names':
-                    allowedpkgnms.append(args.strip())
+                    allowedpkgnms.extend(arg.strip() for arg in args.split(','))
                 elif opname == 'inherited-members':
                     inherited_members = True
                 elif opname == 'no-inherited-members':
@@ -271,8 +271,8 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 allowedpkgnms = ''
                 onlylocals = True
             else:
-                allowedpkgnms = ':allowed-package-names: ' + ','.join(allowedpkgnms)
                 onlylocals = allowedpkgnms
+                allowedpkgnms = ':allowed-package-names: ' + ','.join(allowedpkgnms)
 
             # get the two heading chars
             hds = hds.strip()

--- a/sphinx_automodapi/tests/cases/allowed_names/README.md
+++ b/sphinx_automodapi/tests/cases/allowed_names/README.md
@@ -1,0 +1,2 @@
+Documenting a module with classes, functions, and variables that are
+imported from other files, but where only some of those are allowed.

--- a/sphinx_automodapi/tests/cases/allowed_names/input/index.rst
+++ b/sphinx_automodapi/tests/cases/allowed_names/input/index.rst
@@ -1,0 +1,2 @@
+.. automodapi:: sphinx_automodapi.tests.example_module
+   :allowed-package-names: sphinx_automodapi.tests.example_module.classes

--- a/sphinx_automodapi/tests/cases/allowed_names/output/api/sphinx_automodapi.tests.example_module.Egg.rst
+++ b/sphinx_automodapi/tests/cases/allowed_names/output/api/sphinx_automodapi.tests.example_module.Egg.rst
@@ -1,0 +1,29 @@
+Egg
+===
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autoclass:: Egg
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~Egg.weight
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Egg.buy
+      ~Egg.eat
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: weight
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: buy
+   .. automethod:: eat

--- a/sphinx_automodapi/tests/cases/allowed_names/output/api/sphinx_automodapi.tests.example_module.Spam.rst
+++ b/sphinx_automodapi/tests/cases/allowed_names/output/api/sphinx_automodapi.tests.example_module.Spam.rst
@@ -1,0 +1,7 @@
+Spam
+====
+
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autoclass:: Spam
+   :show-inheritance:

--- a/sphinx_automodapi/tests/cases/allowed_names/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/allowed_names/output/index.rst.automodapi
@@ -1,0 +1,21 @@
+
+sphinx_automodapi.tests.example_module Package
+----------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module
+    :classes-only:
+    :toctree: api
+    :allowed-package-names: sphinx_automodapi.tests.example_module.classes
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module
+    :private-bases:
+    :parts: 1
+    :allowed-package-names: sphinx_automodapi.tests.example_module.classes

--- a/sphinx_automodapi/tests/cases/allowed_names/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/allowed_names/output/index.rst.automodsumm
@@ -1,0 +1,7 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module
+
+.. autosummary::
+    :toctree: api
+
+    Egg
+    Spam

--- a/sphinx_automodapi/tests/example_module/noall.py
+++ b/sphinx_automodapi/tests/example_module/noall.py
@@ -1,0 +1,23 @@
+"""
+A collection of useful classes and functions
+"""
+from collections import OrderedDict
+
+
+def add(a, b):
+    """
+    Add two numbers
+    """
+    return a + b
+
+
+class MixedSpam(OrderedDict):
+    """
+    Special spam
+    """
+
+    def eat(self, time):
+        """
+        Eat special spam in the required time.
+        """
+        pass

--- a/sphinx_automodapi/tests/test_automodsumm.py
+++ b/sphinx_automodapi/tests/test_automodsumm.py
@@ -3,6 +3,7 @@
 
 from copy import copy
 
+import pytest
 from docutils.parsers.rst import directives, roles
 
 from . import cython_testpackage  # noqa
@@ -105,6 +106,54 @@ def test_too_many_options(tmpdir, capsys):
     stdout, stderr = capsys.readouterr()
     assert ("[automodsumm] Defined more than one of functions-only, "
             "classes-only, and variables-only.  Skipping this directive." in stderr)
+
+
+ORDEREDDICT_RST = """
+:orphan:
+
+OrderedDict
+===========
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.noall
+
+.. autoclass:: OrderedDict
+   :show-inheritance:
+""".strip()
+
+
+@pytest.mark.parametrize('options,expect', [
+    ('', ['add', 'MixedSpam']),
+    (':allowed-package-names: sphinx_automodapi', ['add', 'MixedSpam']),
+    (':allowed-package-names: collections', ['OrderedDict']),
+    (':allowed-package-names: sphinx_automodapi,collections',
+     ['add', 'MixedSpam', 'OrderedDict']),
+])
+def test_am_allowed_package_names(options, expect, tmpdir):
+    """
+    Test that allowed_package_names is interpreted correctly.
+    """
+    def mixed2noall(s):
+        return s.replace('example_module.mixed', 'example_module.noall')
+
+    am_str = ams_to_asmry_str
+    with open(tmpdir.join('index.rst').strpath, 'w') as f:
+        f.write(mixed2noall(am_str).format(options=('   '+options if options else '')))
+
+    apidir = tmpdir.mkdir('api')
+    with open(apidir.join('sphinx_automodapi.tests.example_module.noall.add.rst').strpath, 'w') as f:
+        f.write(mixed2noall(ADD_RST))
+    with open(apidir.join('sphinx_automodapi.tests.example_module.noall.MixedSpam.rst').strpath, 'w') as f:
+        f.write(mixed2noall(MIXEDSPAM_RST))
+    with open(apidir.join('sphinx_automodapi.tests.example_module.noall.OrderedDict.rst').strpath, 'w') as f:
+        f.write(ORDEREDDICT_RST)
+
+    run_sphinx_in_tmpdir(tmpdir)
+
+    with open(tmpdir.join('index.rst.automodsumm').strpath) as f:
+        result = f.read()
+
+    for x in expect:
+        assert '   '+x in result
 
 
 PILOT_RST = """

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -74,7 +74,8 @@ def test_run_full_case(tmpdir, case_dir, parallel):
                  'automodsumm_writereprocessed': True})
 
     if os.path.basename(case_dir) in ('mixed_toplevel',
-                                      'mixed_toplevel_all_objects'):
+                                      'mixed_toplevel_all_objects',
+                                      'allowed_names'):
         conf['extensions'].append('sphinx_automodapi.smart_resolver')
 
     start_dir = os.path.abspath('.')

--- a/sphinx_automodapi/tests/test_utils.py
+++ b/sphinx_automodapi/tests/test_utils.py
@@ -22,3 +22,24 @@ def test_find_mod_objs():
     assert 'namedtuple' not in lnms
     assert 'collections.namedtuple' not in fqns
     assert namedtuple not in objs
+
+
+def test_find_mod_objs_with_list_of_modules():
+    lnms, fqns, objs = find_mod_objs(
+        'sphinx_automodapi.tests.test_utils', onlylocals=['sphinx_automodapi'])
+
+    assert namedtuple not in objs
+    assert find_mod_objs in objs
+
+    lnms, fqns, objs = find_mod_objs(
+        'sphinx_automodapi.tests.test_utils', onlylocals=['collections'])
+
+    assert namedtuple in objs
+    assert find_mod_objs not in objs
+
+    lnms, fqns, objs = find_mod_objs(
+        'sphinx_automodapi.tests.test_utils', onlylocals=['collections',
+                                                          'sphinx_automodapi'])
+
+    assert namedtuple in objs
+    assert find_mod_objs in objs


### PR DESCRIPTION
The present implementation of ``:allowed-package-names:`` was rather broken, as I found out when trying to use it on a module that is filled using entry points. This makes at least my case work.

cc @astrofrog - I note that there are quite a few PRs pending. Maybe good to try to get help in maintaining this??? (I may be able to do some).