### PR TITLE
Always use .rst extension

### DIFF
--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -264,11 +264,10 @@ def process_automodsumm_generation(app):
                         f.write('\n')
 
     for sfn, lines in zip(filestosearch, liness):
-        suffix = os.path.splitext(sfn)[1]
         if len(lines) > 0:
             generate_automodsumm_docs(
                 lines, sfn, app=app, builder=app.builder,
-                suffix=suffix, base_path=app.srcdir,
+                base_path=app.srcdir,
                 inherited_members=app.config.automodsumm_inherited_members)
 
 


### PR DESCRIPTION
I am trying to use automodapi with opsdroid, where we use `.md` files rather than `.rst` files as our narrative docs. This means that when we generate api docs with automodapi they get given a `.md` extension, which is just clearly wrong.

I don't really understand why we are generating ReST files with anything other than a `.rst` extension?!