### PR TITLE
Support for non-default dataclass fields

### DIFF
--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -62,10 +62,17 @@ def type_object_attrgetter(obj, attr, *defargs):
 
     try:
         return getattr(obj, attr, *defargs)
-    except AttributeError:
+    except AttributeError as e:
         # for dataclasses, get the attribute from the __dataclass_fields__
         if dataclasses.is_dataclass(obj):
-            return obj.__dataclass_fields__[attr].name
+            if attr in obj.__dataclass_fields__:
+                return obj.__dataclass_fields__[attr].name
+            else:
+                # raise original AttributeError
+                raise e
+        else:
+            # raise original AttributeError
+            raise e
 
 
 def setup(app):

--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -1,6 +1,8 @@
 """
 Miscellaneous enhancements to help autodoc along.
 """
+import dataclasses
+
 from sphinx.ext.autodoc import AttributeDocumenter
 
 __all__ = []
@@ -58,7 +60,12 @@ def type_object_attrgetter(obj, attr, *defargs):
                 return base.__dict__[attr]
             break
 
-    return getattr(obj, attr, *defargs)
+    try:
+        return getattr(obj, attr, *defargs)
+    except AttributeError:
+        # for dataclasses, get the attribute from the __dataclass_fields__
+        if dataclasses.is_dataclass(obj):
+            return obj.__dataclass_fields__[attr].name
 
 
 def setup(app):

--- a/sphinx_automodapi/tests/test_autodoc_enhancements.py
+++ b/sphinx_automodapi/tests/test_autodoc_enhancements.py
@@ -41,3 +41,20 @@ def test_type_attrgetter():
 
     assert type_object_attrgetter(MyClass, 'susy', 'default') == 'default'
     assert type_object_attrgetter(MyClass, '__dict__') == MyClass.__dict__
+
+
+def test_type_attrgetter_for_dataclass():
+    """
+    This tests the attribute getter for non-default dataclass fields
+    """
+    import dataclasses
+
+    @dataclasses.dataclass
+    class MyDataclass:
+        foo: int
+        bar: str = "bar value"
+
+    with pytest.raises(AttributeError):
+        getattr(MyDataclass, 'foo')
+    assert type_object_attrgetter(MyDataclass, 'foo') == 'foo'
+    assert getattr(MyDataclass, 'bar') == 'bar value'


### PR DESCRIPTION
Hi, this PR tries to fix this issue: https://github.com/astropy/sphinx-automodapi/issues/115.
Used sphinx version: 3.2.1
Python version: 3.8.5

Fix #115