### PR TITLE
Options to document private/special methods

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -100,9 +100,6 @@ jobs:
       run: choco install graphviz
     - name: Install tox
       run: python -m pip install tox
-    - name: Install codecov
-      if: ${{ contains(matrix.toxenv,'-cov') }}
-      run: python -m pip install codecov
     - name: Run tox
       run: tox ${{ matrix.toxargs }} -v -e ${{ matrix.toxenv }}
     - name: Upload coverage to codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ test =
     pytest
     pytest-cov
     cython
-    codecov
     coverage
 
 [options.package_data]

--- a/sphinx_automodapi/tests/cases/private_methods/README.md
+++ b/sphinx_automodapi/tests/cases/private_methods/README.md
@@ -1,0 +1,2 @@
+Documenting a module with classes, also including private methods 
+for a particular list of classes.

--- a/sphinx_automodapi/tests/cases/private_methods/input/index.rst
+++ b/sphinx_automodapi/tests/cases/private_methods/input/index.rst
@@ -1,0 +1,1 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.private_classes

--- a/sphinx_automodapi/tests/cases/private_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Banana.rst
+++ b/sphinx_automodapi/tests/cases/private_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Banana.rst
@@ -1,0 +1,19 @@
+Banana
+======
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.private_classes
+
+.. autoclass:: Banana
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Banana._energy
+      ~Banana.eat
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: _energy
+   .. automethod:: eat

--- a/sphinx_automodapi/tests/cases/private_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Fruit.rst
+++ b/sphinx_automodapi/tests/cases/private_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Fruit.rst
@@ -1,0 +1,31 @@
+Fruit
+=====
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.private_classes
+
+.. autoclass:: Fruit
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~Fruit.weight
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Fruit._out_of_date
+      ~Fruit.buy
+      ~Fruit.eat
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: weight
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: _out_of_date
+   .. automethod:: buy
+   .. automethod:: eat

--- a/sphinx_automodapi/tests/cases/private_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Orange.rst
+++ b/sphinx_automodapi/tests/cases/private_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Orange.rst
@@ -1,0 +1,17 @@
+Orange
+======
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.private_classes
+
+.. autoclass:: Orange
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Orange.eat
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: eat

--- a/sphinx_automodapi/tests/cases/private_methods/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/private_methods/output/index.rst.automodapi
@@ -1,0 +1,19 @@
+
+sphinx_automodapi.tests.example_module.private_classes Module
+-------------------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.private_classes
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.private_classes
+    :classes-only:
+    :toctree: api
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module.private_classes
+    :private-bases:
+    :parts: 1

--- a/sphinx_automodapi/tests/cases/private_methods/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/private_methods/output/index.rst.automodsumm
@@ -1,0 +1,9 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.private_classes
+
+.. autosummary::
+    :toctree: api
+
+    Fruit
+    Banana
+    Orange
+

--- a/sphinx_automodapi/tests/cases/special_methods/README.md
+++ b/sphinx_automodapi/tests/cases/special_methods/README.md
@@ -1,0 +1,2 @@
+Documenting a module with classes, also including special methods 
+for a particular list of classes.

--- a/sphinx_automodapi/tests/cases/special_methods/input/index.rst
+++ b/sphinx_automodapi/tests/cases/special_methods/input/index.rst
@@ -1,0 +1,1 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.private_classes

--- a/sphinx_automodapi/tests/cases/special_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Banana.rst
+++ b/sphinx_automodapi/tests/cases/special_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Banana.rst
@@ -1,0 +1,17 @@
+Banana
+======
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.private_classes
+
+.. autoclass:: Banana
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Banana.eat
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: eat

--- a/sphinx_automodapi/tests/cases/special_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Fruit.rst
+++ b/sphinx_automodapi/tests/cases/special_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Fruit.rst
@@ -1,0 +1,31 @@
+Fruit
+=====
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.private_classes
+
+.. autoclass:: Fruit
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~Fruit.weight
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Fruit.__len__
+      ~Fruit.buy
+      ~Fruit.eat
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: weight
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: __len__
+   .. automethod:: buy
+   .. automethod:: eat

--- a/sphinx_automodapi/tests/cases/special_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Orange.rst
+++ b/sphinx_automodapi/tests/cases/special_methods/output/api/sphinx_automodapi.tests.example_module.private_classes.Orange.rst
@@ -1,0 +1,19 @@
+Orange
+======
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.private_classes
+
+.. autoclass:: Orange
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Orange.__add__
+      ~Orange.eat
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: __add__
+   .. automethod:: eat

--- a/sphinx_automodapi/tests/cases/special_methods/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/special_methods/output/index.rst.automodapi
@@ -1,0 +1,19 @@
+
+sphinx_automodapi.tests.example_module.private_classes Module
+-------------------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.private_classes
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.private_classes
+    :classes-only:
+    :toctree: api
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module.private_classes
+    :private-bases:
+    :parts: 1

--- a/sphinx_automodapi/tests/cases/special_methods/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/special_methods/output/index.rst.automodsumm
@@ -1,0 +1,9 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.private_classes
+
+.. autosummary::
+    :toctree: api
+
+    Fruit
+    Banana
+    Orange
+

--- a/sphinx_automodapi/tests/example_module/private_classes.py
+++ b/sphinx_automodapi/tests/example_module/private_classes.py
@@ -1,0 +1,90 @@
+__all__ = ['Fruit', 'Banana', 'Orange']
+
+
+class Fruit(object):
+    """
+    An fruit
+    """
+    def eat(self, time):
+        """
+        Eat apple.
+        """
+        pass
+
+    def buy(self, price):
+        """
+        Buy apple.
+        """
+        pass
+
+    @property
+    def weight(self):
+        """
+        The weight of the apple.
+        """
+        return 0
+
+    @property
+    def _age(self):
+        """
+        The age of the fruit.
+        """
+        return 0
+
+    def __len__(self):
+        """
+        The length the fruit.
+        """
+        return 0
+
+    def _out_of_date(self, date):
+        """
+        Is it out of date?
+        """
+        pass
+
+
+class Banana(Fruit):
+    """
+    A banana
+    """
+    def eat(self, time):
+        """
+        Eat banana.
+        """
+        pass
+
+    def _energy(self, units='kcal'):
+        """
+        The energy in the banana.
+        """
+        pass
+
+    def __add__(self, other):
+        """
+        How to add the banana to something.
+        """
+        pass
+
+
+class Orange(Fruit):
+    """
+    An orange
+    """
+    def eat(self, time):
+        """
+        Eat orange.
+        """
+        pass
+
+    def _energy(self, units='kcal'):
+        """
+        The energy in the orange.
+        """
+        pass
+
+    def __add__(self, other):
+        """
+        How to add the orange to something.
+        """
+        pass

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -76,6 +76,11 @@ def test_run_full_case(tmpdir, case_dir, parallel):
                                       'allowed_names'):
         conf['extensions'].append('sphinx_automodapi.smart_resolver')
 
+    if os.path.basename(case_dir) == 'private_methods':
+        conf['automodsumm_private_methods_of'] = [
+            'sphinx_automodapi.tests.example_module.private_classes.Fruit',
+            'sphinx_automodapi.tests.example_module.private_classes.Banana',
+        ]
     start_dir = os.path.abspath('.')
 
     src_dir = 'src' if 'source_dir' in case_dir else '.'

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -81,6 +81,12 @@ def test_run_full_case(tmpdir, case_dir, parallel):
             'sphinx_automodapi.tests.example_module.private_classes.Fruit',
             'sphinx_automodapi.tests.example_module.private_classes.Banana',
         ]
+    if os.path.basename(case_dir) == 'special_methods':
+        conf['automodsumm_special_methods_of'] = [
+            'sphinx_automodapi.tests.example_module.private_classes.Fruit',
+            'sphinx_automodapi.tests.example_module.private_classes.Orange',
+        ]
+
     start_dir = os.path.abspath('.')
 
     src_dir = 'src' if 'source_dir' in case_dir else '.'


### PR DESCRIPTION
Implements two new options for enabling the documenting of private and/or special methods. Only enabled for class names listed in config file. Class names must be given in full, e.g.,`` module.submodule.classname``. These options are useful for including private/special methods of base classes in documentation intended for new developers. This helps a new developer quickly create a new subclass, which makes use of, or overrides, private methods in the base class.

* ``automodsumm_private_methods_of``
    Should be a list of fully qualified names of classes where all of its
    private methods (i.e., method names beginning with an underscore, but
    not ending with a double underscore) should be documented. Defaults to ``[]``.

* ``automodsumm_special_methods_of``
    Should be a list of fully qualified names of classes where all of its
    special methods (i.e., method names beginning with a double underscore and
    ending with a double underscore) should be documented. Defaults to ``[]``.

Two new test cases are included, ensuring that each option only includes methods (either private or special) for the specified class names. Also ensures that the new options do not enable in the inclusion of extra private/special _attributes_.