### PR TITLE
Add :include: option, to do the opposite of :skip:

### DIFF
--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -327,6 +327,54 @@ def test_am_replacer_skip(tmpdir):
     assert result == am_replacer_skip_expected
 
 
+am_replacer_include_str = """
+This comes before
+
+.. automodapi:: sphinx_automodapi.tests.example_module.functions
+    :include: add
+    :include: subtract
+
+This comes after
+"""
+
+am_replacer_include_expected = """
+This comes before
+
+
+sphinx_automodapi.tests.example_module.functions Module
+-------------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.functions
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.functions
+    :functions-only:
+    :toctree: api
+    :skip: multiply
+
+
+This comes after
+""".format(empty='')
+
+
+def test_am_replacer_include(tmpdir):
+    """
+    Tests using the ":include: option in an ".. automodapi::" .
+    """
+
+    with open(tmpdir.join('index.rst').strpath, 'w') as f:
+        f.write(am_replacer_include_str.format(options=''))
+
+    run_sphinx_in_tmpdir(tmpdir)
+
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
+        result = f.read()
+
+    assert result == am_replacer_include_expected
+
+
 am_replacer_invalidop_str = """
 This comes before
 


### PR DESCRIPTION
This is a potential solution for #92: This adds an `:include:` option to `automodapi`, if a user only wants to, e.g., pick a few object names to generate documentation for with `automodapi`. 

This is kind of a hack, because this implementation takes any object found that does not appear in `:include:` and adds them to the list of object names to skip before passing on to `automodsumm`. But hey, it seems to work 🤷‍♂️