### PR TITLE
sphinx_automodapi/automodsumm.py: address #132

### DIFF
--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -539,7 +539,7 @@ def generate_automodsumm_docs(lines, srcfn, app=None, suffix='.rst',
                     # class `__dict__` instead.
                     declares_slots = (
                         hasattr(obj, '__slots__') and
-                        not (type(obj) is abc.ABCMeta and
+                        not (issubclass(type(obj), abc.ABCMeta) and
                              len(obj.__slots__) == 0)
                     )
 


### PR DESCRIPTION
The members of ABC-derived classes were not being listed when they used a custom metaclass deriving from ABCMeta. The fix is not just test for exact equality of the ABCMeta metaclass, but subclassness.