### PR TITLE
Avoid warnings when accessing attributes on classes that may not be regular properties

### DIFF
--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -1,6 +1,7 @@
 """
 Miscellaneous enhancements to help autodoc along.
 """
+import warnings
 from sphinx.ext.autodoc import AttributeDocumenter
 
 __all__ = []
@@ -58,7 +59,13 @@ def type_object_attrgetter(obj, attr, *defargs):
                 return base.__dict__[attr]
             break
 
-    return getattr(obj, attr, *defargs)
+    # In some cases, getting attributes with getattr can lead to warnings, e.g.
+    # deprecation warnings (this is not normally the case with methods and
+    # regular properties since we don't execute them but using getattr does run
+    # the code inside those properties, so we filter out any warnings.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        return getattr(obj, attr, *defargs)
 
 
 def setup(app):

--- a/sphinx_automodapi/tests/cases/class_with_property_warning/README.md
+++ b/sphinx_automodapi/tests/cases/class_with_property_warning/README.md
@@ -1,0 +1,1 @@
+Documenting a module with a class that has a non-standard property that emits a warning

--- a/sphinx_automodapi/tests/cases/class_with_property_warning/input/index.rst
+++ b/sphinx_automodapi/tests/cases/class_with_property_warning/input/index.rst
@@ -1,0 +1,1 @@
+.. automodapi:: sphinx_automodapi.tests.example_module.class_with_property_warning

--- a/sphinx_automodapi/tests/cases/class_with_property_warning/output/api/sphinx_automodapi.tests.example_module.class_with_property_warning.Camelot.rst
+++ b/sphinx_automodapi/tests/cases/class_with_property_warning/output/api/sphinx_automodapi.tests.example_module.class_with_property_warning.Camelot.rst
@@ -1,0 +1,19 @@
+Camelot
+=======
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.class_with_property_warning
+
+.. autoclass:: Camelot
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~Camelot.place
+      ~Camelot.silly
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: place
+   .. autoattribute:: silly

--- a/sphinx_automodapi/tests/cases/class_with_property_warning/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/class_with_property_warning/output/index.rst.automodapi
@@ -1,0 +1,19 @@
+
+sphinx_automodapi.tests.example_module.class_with_property_warning Module
+-------------------------------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.class_with_property_warning
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.class_with_property_warning
+    :classes-only:
+    :toctree: api
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module.class_with_property_warning
+    :private-bases:
+    :parts: 1

--- a/sphinx_automodapi/tests/cases/class_with_property_warning/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/class_with_property_warning/output/index.rst.automodsumm
@@ -1,0 +1,6 @@
+.. currentmodule:: sphinx_automodapi.tests.example_module.class_with_property_warning
+
+.. autosummary::
+    :toctree: api
+
+    Camelot

--- a/sphinx_automodapi/tests/example_module/class_with_property_warning.py
+++ b/sphinx_automodapi/tests/example_module/class_with_property_warning.py
@@ -1,0 +1,29 @@
+import warnings
+
+__all__ = ['Camelot']
+
+
+class customproperty:
+    def __init__(self, getter):
+        self.getter = getter
+
+    def __get__(self, instance, owner):
+        return self.getter(owner)
+
+
+
+class Camelot(object):
+    """
+    A class where a property emits a warning
+    """
+
+    @customproperty
+    def silly(cls):
+        warnings.warn("It is VERY silly", UserWarning)
+
+    @property
+    def place(self):
+        """
+        Indeed.
+        """
+        pass

--- a/sphinx_automodapi/tests/test_cases.py
+++ b/sphinx_automodapi/tests/test_cases.py
@@ -99,11 +99,20 @@ def test_run_full_case(tmpdir, case_dir, parallel):
 
     try:
         os.chdir(docs_dir)
-        status = build_main(argv=argv)
+        with pytest.warns(None) as record:
+            status = build_main(argv=argv)
     finally:
         os.chdir(start_dir)
 
     assert status == 0
+
+    # Make sure there are no warnings - if there are we print them out for debugging
+    if len(record) > 0:
+        print('Build emitted the following unexpected warnings:')
+        for warning in record:
+            print('  ' + str(warning))
+
+    assert len(record) == 0
 
     # Check that all expected output files are there and match the reference files
     for root, dirnames, filenames in os.walk(output_dir):


### PR DESCRIPTION
In astropy core, we need to do horrendous things like:

https://github.com/astropy/astropy/blob/46ca59e9a0bfa3b6687411ea7a6364fdebf91914/astropy/visualization/wcsaxes/patches.py#L17-L26

because sometimes Matplotlib deprecate properties - however because those are custom properties and not regular properties, we make use of getattr in sphinx-automodapi to access these which triggers the code inside the properties to run. So this PR just ignores any warning that may occur from running those properties which I think is sensible since there's nothing we can do about those warnings.

The test I added still fails though as the warning still appears a few times (the fix I did takes it down from 7 to 4 warnings). If anyone else fancies figuring out how to fix the test that would be great! Otherwise I'll try and pick this up when I have some time again (but probably not for another month :-/)