### PR TITLE
Set default value for env.intersphinx_named_inventory

### DIFF
--- a/sphinx_automodapi/smart_resolver.py
+++ b/sphinx_automodapi/smart_resolver.py
@@ -102,7 +102,7 @@ def missing_reference_handler(app, env, node, contnode):
                     suffix = '.' + suffix
                 reftarget = reftarget + suffix
                 prefix = reftarget.rsplit('.')[0]
-                inventory = env.intersphinx_named_inventory
+                inventory = getattr(env, 'intersphinx_named_inventory', {})
                 if (reftarget not in mapping and
                         prefix in inventory):
 


### PR DESCRIPTION
If intersphinx isn't used `env.intersphinx_named_inventory` fails in `smart_resolver.py`. This PR uses `getattr` to allow the default value of `{}`.

Closes #110
Closes #122 