### PR TITLE
Add test of :skip: with stdlib objects

### DIFF
--- a/sphinx_automodapi/tests/example_module/stdlib.py
+++ b/sphinx_automodapi/tests/example_module/stdlib.py
@@ -1,0 +1,12 @@
+"""
+A module that imports objects from the standard library.
+"""
+from pathlib import Path
+from datetime import time
+
+
+def add(a, b):
+    """
+    Add two numbers
+    """
+    return a + b

--- a/sphinx_automodapi/tests/example_module/stdlib.py
+++ b/sphinx_automodapi/tests/example_module/stdlib.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from datetime import time
 
 
+__all__ = ['Path', 'time', 'add']
+
+
 def add(a, b):
     """
     Add two numbers

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -327,6 +327,56 @@ def test_am_replacer_skip(tmpdir):
     assert result == am_replacer_skip_expected
 
 
+am_replacer_skip_stdlib_str = """
+This comes before
+
+.. automodapi:: sphinx_automodapi.tests.example_module.stdlib
+    :skip: time
+    :skip: Path
+
+This comes after
+"""
+
+
+am_replacer_skip_stdlib_expected = """
+This comes before
+
+
+sphinx_automodapi.tests.example_module.stdlib Module
+----------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.stdlib
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.stdlib
+    :functions-only:
+    :toctree: api
+    :skip: time,Path
+
+
+This comes after
+""".format(empty='')
+
+
+def test_am_replacer_skip_stdlib(tmpdir):
+    """
+    Tests using the ":skip:" option in an ".. automodapi::"
+    that skips objects imported from the standard library.
+    """
+
+    with open(tmpdir.join('index.rst').strpath, 'w') as f:
+        f.write(am_replacer_skip_stdlib_str.format(options=''))
+
+    run_sphinx_in_tmpdir(tmpdir)
+
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
+        result = f.read()
+
+    assert result == am_replacer_skip_stdlib_expected
+
+
 am_replacer_include_str = """
 This comes before
 


### PR DESCRIPTION
This adds a (failing) test that demonstrates a bug introduced by #127.  I'll open an issue shortly and link it to this PR.