### PR TITLE
Fix issue with :skip: introduced by :include: feature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes in sphinx-automodapi
 0.15.0 (unreleased)
 -------------------
 
+- Fixed issue with ``:skip:`` introduced by ``:include:`` feature. [#142]
+
 0.14.0 (2021-12-22)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ filterwarnings =
     ignore:The `docutils\.parsers\.rst\.directive\.html` module will be removed:DeprecationWarning
     ignore:'contextfunction' is renamed to 'pass_context':DeprecationWarning
     ignore:'environmentfilter' is renamed to 'pass_environment':DeprecationWarning
+    ignore:distutils Version classes are deprecated:DeprecationWarning
 
 [flake8]
 max-line-length = 125

--- a/sphinx_automodapi/automodapi.py
+++ b/sphinx_automodapi/automodapi.py
@@ -411,12 +411,12 @@ def _mod_info(modname, toskip=[], include=[], onlylocals=True):
 
     hascls = hasfunc = hasother = False
 
-    skips = []
+    skips = toskip.copy()
     for localnm, fqnm, obj in zip(*find_mod_objs(modname, onlylocals=onlylocals)):
-        if localnm in toskip or (include and localnm not in include):
+        if include and localnm not in include and localnm not in skips:
             skips.append(localnm)
 
-        else:
+        elif localnm not in toskip:
             hascls = hascls or inspect.isclass(obj)
             hasfunc = hasfunc or inspect.isroutine(obj)
             hasother = hasother or (not inspect.isclass(obj) and

--- a/sphinx_automodapi/tests/example_module/stdlib.py
+++ b/sphinx_automodapi/tests/example_module/stdlib.py
@@ -1,0 +1,12 @@
+"""
+A module that imports objects from the standard library.
+"""
+from pathlib import Path
+from datetime import time
+
+
+def add(a, b):
+    """
+    Add two numbers
+    """
+    return a + b

--- a/sphinx_automodapi/tests/example_module/stdlib.py
+++ b/sphinx_automodapi/tests/example_module/stdlib.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from datetime import time
 
 
+__all__ = ['Path', 'time', 'add']
+
+
 def add(a, b):
     """
     Add two numbers

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -378,6 +378,56 @@ def test_am_replacer_skip_stdlib(tmpdir):
     assert result == am_replacer_skip_stdlib_expected
 
 
+am_replacer_include_stdlib_str = """
+This comes before
+
+.. automodapi:: sphinx_automodapi.tests.example_module.stdlib
+    :include: add
+    :allowed-package-names: pathlib, datetime, sphinx_automodapi
+
+This comes after
+"""
+
+am_replacer_include_stdlib_expected = """
+This comes before
+
+
+sphinx_automodapi.tests.example_module.stdlib Module
+----------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.stdlib
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.stdlib
+    :functions-only:
+    :toctree: api
+    :skip: Path,time
+    :allowed-package-names: pathlib,datetime,sphinx_automodapi
+
+
+This comes after
+""".format(empty='')
+
+
+def test_am_replacer_include_stdlib(tmpdir):
+    """
+    Tests using the ":include: option in an ".. automodapi::"
+    in the presence of objects imported from the standard library.
+    """
+
+    with open(tmpdir.join('index.rst').strpath, 'w') as f:
+        f.write(am_replacer_include_stdlib_str.format(options=''))
+
+    run_sphinx_in_tmpdir(tmpdir)
+
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
+        result = f.read()
+
+    assert result == am_replacer_include_stdlib_expected
+
+
 am_replacer_include_str = """
 This comes before
 

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -327,6 +327,56 @@ def test_am_replacer_skip(tmpdir):
     assert result == am_replacer_skip_expected
 
 
+am_replacer_skip_stdlib_str = """
+This comes before
+
+.. automodapi:: sphinx_automodapi.tests.example_module.stdlib
+    :skip: time
+    :skip: Path
+
+This comes after
+"""
+
+
+am_replacer_skip_stdlib_expected = """
+This comes before
+
+
+sphinx_automodapi.tests.example_module.stdlib Module
+----------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.stdlib
+
+Functions
+^^^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.stdlib
+    :functions-only:
+    :toctree: api
+    :skip: time,Path
+
+
+This comes after
+""".format(empty='')
+
+
+def test_am_replacer_skip_stdlib(tmpdir):
+    """
+    Tests using the ":skip:" option in an ".. automodapi::"
+    that skips objects imported from the standard library.
+    """
+
+    with open(tmpdir.join('index.rst').strpath, 'w') as f:
+        f.write(am_replacer_skip_stdlib_str.format(options=''))
+
+    run_sphinx_in_tmpdir(tmpdir)
+
+    with open(tmpdir.join('index.rst.automodapi').strpath) as f:
+        result = f.read()
+
+    assert result == am_replacer_skip_stdlib_expected
+
+
 am_replacer_include_str = """
 This comes before
 

--- a/sphinx_automodapi/tests/test_automodapi.py
+++ b/sphinx_automodapi/tests/test_automodapi.py
@@ -364,6 +364,7 @@ def test_am_replacer_skip_stdlib(tmpdir):
     """
     Tests using the ":skip:" option in an ".. automodapi::"
     that skips objects imported from the standard library.
+    This is a regression test for #141
     """
 
     with open(tmpdir.join('index.rst').strpath, 'w') as f:


### PR DESCRIPTION
This is a fix for the bug identified in #141. The fix is implemented in the first commit from me, which simplifies some of the logic and reverts back to looking more like it did before #127 but keeps the new `:include:` functionality.

Note: this includes the commits from #140 which added a useful regression test.

cc @eslavich

EDIT:

* Fix #141 
* Close #140