### PR TITLE
Fix non ascii object members

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes in sphinx-automodapi
 0.15.0 (unreleased)
 -------------------
 
+- Fixed issue with non-ascii characters in object members on Windows as the default encoding there is not ``utf8`` [#153]
+
 0.14.1 (2022-01-12)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes in sphinx-automodapi
 0.15.0 (unreleased)
 -------------------
 
-- Fixed issue with non-ascii characters in object members on Windows as the default encoding there is not ``utf8`` [#153]
+- Fixed issue with non-ascii characters in object members when the encoding is not ``utf8`` [#153]
 
 0.14.1 (2022-01-12)
 -------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ version = '.'.join(release.split('.')[:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -487,7 +487,7 @@ def generate_automodsumm_docs(lines, srcfn, app=None, suffix='.rst',
 
         new_files.append(fn)
 
-        f = open(fn, 'w')
+        f = open(fn, 'w', encoding='utf8')
 
         try:
 

--- a/sphinx_automodapi/tests/cases/non_ascii/input/index.rst
+++ b/sphinx_automodapi/tests/cases/non_ascii/input/index.rst
@@ -1,3 +1,4 @@
 Ceçi est un exemple qui inclus des charactères non-ASCII
 
 .. automodapi:: sphinx_automodapi.tests.example_module.functions
+.. automodapi:: sphinx_automodapi.tests.example_module.nonascii

--- a/sphinx_automodapi/tests/cases/non_ascii/output/api/sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst
+++ b/sphinx_automodapi/tests/cases/non_ascii/output/api/sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst
@@ -1,0 +1,19 @@
+NonAscii
+========
+
+.. currentmodule:: sphinx_automodapi.tests.example_module.nonascii
+
+.. autoclass:: NonAscii
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~NonAscii.get_ß
+      ~NonAscii.get_äöü
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: get_ß
+   .. automethod:: get_äöü

--- a/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodapi
+++ b/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodapi
@@ -12,3 +12,23 @@ Functions
 .. automodsumm:: sphinx_automodapi.tests.example_module.functions
     :functions-only:
     :toctree: api
+
+
+sphinx_automodapi.tests.example_module.nonascii Module
+------------------------------------------------------
+
+.. automodule:: sphinx_automodapi.tests.example_module.nonascii
+
+Classes
+^^^^^^^
+
+.. automodsumm:: sphinx_automodapi.tests.example_module.nonascii
+    :classes-only:
+    :toctree: api
+
+Class Inheritance Diagram
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automod-diagram:: sphinx_automodapi.tests.example_module.nonascii
+    :private-bases:
+    :parts: 1

--- a/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodsumm
@@ -6,6 +6,7 @@
     add
     subtract
     multiply
+ 
 .. currentmodule:: sphinx_automodapi.tests.example_module.nonascii
 
 .. autosummary::

--- a/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodsumm
@@ -6,7 +6,6 @@
     add
     subtract
     multiply
- 
 .. currentmodule:: sphinx_automodapi.tests.example_module.nonascii
 
 .. autosummary::

--- a/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodsumm
+++ b/sphinx_automodapi/tests/cases/non_ascii/output/index.rst.automodsumm
@@ -6,3 +6,10 @@
     add
     subtract
     multiply
+.. currentmodule:: sphinx_automodapi.tests.example_module.nonascii
+
+.. autosummary::
+    :toctree: api
+
+    NonAscii
+

--- a/sphinx_automodapi/tests/example_module/nonascii.py
+++ b/sphinx_automodapi/tests/example_module/nonascii.py
@@ -1,5 +1,6 @@
 __all__ = ['NonAscii']
 
+
 class NonAscii(object):
     def get_äöü(self):
         """

--- a/sphinx_automodapi/tests/example_module/nonascii.py
+++ b/sphinx_automodapi/tests/example_module/nonascii.py
@@ -1,0 +1,14 @@
+__all__ = ['NonAscii']
+
+class NonAscii(object):
+    def get_äöü(self):
+        """
+        Return a string with common umlauts like äöüß
+        """
+        return 'äöü'
+
+    def get_ß(self):
+        """
+        Return a string with the eszett symbol
+        """
+        return 'ß'


### PR DESCRIPTION
I just had an issue with non-ascii-characters in class members (in my case its a column name of a database I access with SQLAlchemy). This PR sets a default `encoding` for `open()` as the default seems to be os-dependent, howevers sphinx expects `utf8`. This fixes my issues on Windows.

I also tried to modify the non-ascii-testcase, however this seems to pass without my fix. If I execute normal `sphinx-build` during command-line it fails:
```shell
sphinx-build . _build
Sphinx v5.1.1 in Verwendung
making output directory... erledigt
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
[autosummary] generating autosummary for: index.rst
[automodsumm] index.rst: found 4 automodsumm entries to generate
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: [new config] 5 added, 0 changed, 0 removed
reading sources... [100%] index                                                onAsciit
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:13: WARNING: undecodable source characters, replacing with "?": b'      ~NonAscii.get_>>>\xdf<<<\r'
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:14: WARNING: undecodable source characters, replacing with "?": b'      ~NonAscii.get_>>>\xe4<<<\xf6\xfc\r'
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:14: WARNING: undecodable source characters, replacing with "?": b'      ~NonAscii.get_\xe4>>>\xf6<<<\xfc\r'
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:14: WARNING: undecodable source characters, replacing with "?": b'      ~NonAscii.get_\xe4\xf6>>>\xfc<<<\r'
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:18: WARNING: undecodable source characters, replacing with "?": b'   .. automethod:: get_>>>\xdf<<<\r'
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:19: WARNING: undecodable source characters, replacing with "?": b'   .. automethod:: get_>>>\xe4<<<\xf6\xfc\r'
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:19: WARNING: undecodable source characters, replacing with "?": b'   .. automethod:: get_\xe4>>>\xf6<<<\xfc\r'
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:19: WARNING: undecodable source characters, replacing with "?": b'   .. automethod:: get_\xe4\xf6>>>\xfc<<<\r'
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:11: WARNING: autosummary: failed to import NonAscii.get_?.
Possible hints:
* AttributeError: type object 'NonAscii' has no attribute 'NonAscii'
* AttributeError: type object 'NonAscii' has no attribute 'get_?'
* ModuleNotFoundError: No module named 'sphinx_automodapi.tests.example_module.nonascii.NonAscii'; 'sphinx_automodapi.tests.example_module.nonascii' is not a package
* ModuleNotFoundError: No module named 'NonAscii'
* ImportError:
C:\Users\USER\path\to\test\api\sphinx_automodapi.tests.example_module.nonascii.NonAscii.rst:11: WARNING: autosummary: failed to import NonAscii.get_???.
Possible hints:
* AttributeError: type object 'NonAscii' has no attribute 'NonAscii'
* AttributeError: type object 'NonAscii' has no attribute 'get_???'
* ModuleNotFoundError: No module named 'sphinx_automodapi.tests.example_module.nonascii.NonAscii'; 'sphinx_automodapi.tests.example_module.nonascii' is not a package
* ModuleNotFoundError: No module named 'NonAscii'
* ImportError:
* KeyError: 'NonAscii'
WARNING: invalid signature for automethod ('get_?')
WARNING: don't know which module to import for autodocumenting 'get_?' (try placing a "module" or "currentmodule" directive in the document, or giving an explicit module name)  
WARNING: don't know which module to import for autodocumenting 'get_???' (try placing a "module" or "currentmodule" directive in the document, or giving an explicit module name)looking for now-outdated files... none found
pickling environment... erledigt
checking consistency... erledigt
preparing documents... erledigt
writing output... [100%] index                                                 nAsciit
generating indices... genindex py-modindex erledigt
writing additional pages... search erledigt
copying static files... erledigt
copying extra files... erledigt
dumping search index in English (code: en)... erledigt
dumping object inventory... erledigt
build abgeschlossen, 14 warnings.

The HTML pages are in _build.
```