### PR TITLE
Remove PyPI codecov

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,7 +18,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - name: Code style checks

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -100,9 +100,6 @@ jobs:
       run: choco install graphviz
     - name: Install tox
       run: python -m pip install tox
-    - name: Install codecov
-      if: ${{ contains(matrix.toxenv,'-cov') }}
-      run: python -m pip install codecov
     - name: Run tox
       run: tox ${{ matrix.toxargs }} -v -e ${{ matrix.toxenv }}
     - name: Upload coverage to codecov

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -7,8 +7,8 @@ on:
     tags: '*'
   workflow_dispatch:
   schedule:
-    # Monthly cron
-    - cron: '0 8 1 * *'
+    # Weekly cron
+    - cron: '0 8 * * 1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ test =
     pytest
     pytest-cov
     cython
-    codecov
     coverage
 
 [options.package_data]


### PR DESCRIPTION
Remove the codecov PyPI package from the dependencies. The workflow is already using the codecov uploader action, so this should not be needed, unless coverage needs to uploaded from elsewhere?