### PR TITLE
MAINT: ignoring pip deprecation issued for old pythons

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ filterwarnings =
     ignore:The alias 'sphinx\.util\.progress_message' is deprecated
     ignore:Deprecated call to.*pkg_resources\.declare_namespace:DeprecationWarning
     ignore:.*suffix for Jinja templates is deprecated
+    # pip 23.1 issue:
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
 
 [flake8]
 max-line-length = 125


### PR DESCRIPTION
This should fix all the CI failures we see on `main`: https://github.com/astropy/sphinx-automodapi/actions/runs/4748458397/jobs/8434673280