### PR TITLE
Fix: remove ignore of reverted deprecation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ filterwarnings =
     ignore:The alias 'sphinx\.util\.SkipProgressMessage' is deprecated
     ignore:The alias 'sphinx\.util\.progress_message' is deprecated
     ignore:Deprecated call to.*pkg_resources\.declare_namespace:DeprecationWarning
-    ignore:.*suffix for Jinja templates is deprecated
     # pip 23.1 issue:
     ignore:pkg_resources is deprecated as an API:DeprecationWarning
 


### PR DESCRIPTION
This deprecation warning has been reverted, so we shouldn't ignore the warning.