### PR TITLE
Fix broken inheritance-diagram links due to the smart resolver

### DIFF
--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -635,7 +635,7 @@ def generate_automodsumm_docs(lines, srcfn, app=None, suffix='.rst',
                 # An important subtlety here is that the path we pass in has
                 # to be relative to the file being generated, so we have to
                 # figure out the right number of '..'s
-                ndirsback = path.replace(base_path, '').count(os.sep)
+                ndirsback = path.replace(str(base_path), '').count(os.sep)
                 ref_file_rel_segments = ['..'] * ndirsback
                 ref_file_rel_segments.append(mod_name_dir)
                 ref_file_rel_segments.append('references.txt')


### PR DESCRIPTION
sphinx-doc/sphinx#10614 fixes many of the broken inheritance-diagram links (#48).  The remaining broken links are due to a bad interaction with `sphinx-automodapi`'s smart resolver.  

`sphinx.ext.inheritance_diagram` generates a list of class full names (e.g., `astropy.coordinates.baseframe.BaseCoordinateFrame`) and generates a mapping from class full names to documentation URLs.  However, the smart resolver causes the generated mapping to be instead from class documented name (e.g., `astropy.coordinates.BaseCoordinateFrame`) to documentation URLs.  The class documented name can be different from the class full name if the class is not documented where it is defined, but rather at some other location where it is imported.  In such situations, the code will fail to find the URL that for the class.

This PR monkey-patches the method that receives the mapping and converts the keys from class documented names to class full names.

Also address #173 (but not the part about updating matrix)