### PR TITLE
MNT: Drop Python 3.7 and update test matrix again

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -28,11 +28,11 @@ jobs:
 
           # Linux - test different Sphinx versions
           - os: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37-test-sphinx40
-          - os: ubuntu-latest
             python-version: 3.8
-            toxenv: py38-test-sphinx53
+            toxenv: py38-test-sphinx40
+          - os: ubuntu-latest
+            python-version: 3.9
+            toxenv: py39-test-sphinx53
           - os: ubuntu-latest
             python-version: 3.9
             toxenv: py39-test-sphinx62
@@ -41,7 +41,7 @@ jobs:
             toxenv: py310-test-sphinx70
           - os: ubuntu-latest
             python-version: '3.11'
-            toxenv: py311-test-sphinx71-cov-clocale
+            toxenv: py311-test-sphinx72-cov-clocale
           - os: ubuntu-latest
             python-version: '3.12-dev'
             toxenv: py312-test-sphinxdev
@@ -49,18 +49,18 @@ jobs:
           # MacOS X - just the stable and dev
           - os: macos-latest
             python-version: '3.10'
-            toxenv: py310-test-sphinx71-clocale
+            toxenv: py310-test-sphinx72-clocale
           - os: macos-latest
             python-version: '3.11'
             toxenv: py311-test-sphinxdev
 
           # Windows - just the oldest, stable, and dev
           - os: windows-latest
-            python-version: 3.7
-            toxenv: py37-test-sphinx40
+            python-version: 3.8
+            toxenv: py38-test-sphinx40
           - os: windows-latest
             python-version: '3.10'
-            toxenv: py310-test-sphinx71
+            toxenv: py310-test-sphinx72
           - os: windows-latest
             python-version: '3.11'
             toxenv: py311-test-sphinxdev

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -32,13 +32,13 @@ jobs:
             toxenv: py38-test-sphinx40
           - os: ubuntu-latest
             python-version: 3.9
-            toxenv: py39-test-sphinx53
-          - os: ubuntu-latest
-            python-version: 3.9
             toxenv: py39-test-sphinx62
           - os: ubuntu-latest
+            python-version: 3.9
+            toxenv: py39-test-sphinx70
+          - os: ubuntu-latest
             python-version: '3.10'
-            toxenv: py310-test-sphinx70
+            toxenv: py310-test-sphinx71
           - os: ubuntu-latest
             python-version: '3.11'
             toxenv: py311-test-sphinx72-cov-clocale

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -31,6 +31,9 @@ jobs:
             python-version: 3.8
             toxenv: py38-test-sphinx40
           - os: ubuntu-latest
+            python-version: 3.8
+            toxenv: py38-test-sphinx53
+          - os: ubuntu-latest
             python-version: 3.9
             toxenv: py39-test-sphinx62
           - os: ubuntu-latest

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -29,7 +29,7 @@ jobs:
           # Linux - test different Sphinx versions
           - os: ubuntu-latest
             python-version: 3.8
-            toxenv: py38-test-sphinx40
+            toxenv: py38-test-sphinx_oldest
           - os: ubuntu-latest
             python-version: 3.8
             toxenv: py38-test-sphinx53

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes in sphinx-automodapi
 0.17.0 (unreleased)
 -------------------
 
+- Minimum supported Python version is now 3.8. [#177]
+
 0.16.0 (2023-08-17)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     sphinx>=4
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312}-test-sphinx{40,62,70,71,72,dev}{-cov}{-clocale}
+envlist = py{38,39,310,311,312}-test-sphinx{40,53,62,70,71,72,dev}{-cov}{-clocale}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 isolated_build = true
@@ -8,6 +8,7 @@ isolated_build = true
 changedir = .tmp/{envname}
 deps =
     sphinx40: sphinx==4.0.0
+    sphinx53: sphinx==5.3.*
     sphinx62: sphinx==6.2.*
     sphinx70: sphinx==7.0.*
     sphinx71: sphinx==7.1.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312}-test-sphinx{40,53,62,70,71,dev}{-cov}{-clocale}
+envlist = py{38,39,310,311,312}-test-sphinx{40,53,62,70,72,dev}{-cov}{-clocale}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 isolated_build = true
@@ -11,7 +11,7 @@ deps =
     sphinx53: sphinx==5.3.*
     sphinx62: sphinx==6.2.*
     sphinx70: sphinx==7.0.*
-    sphinx71: sphinx==7.1.*
+    sphinx72: sphinx==7.2.*
     sphinxdev: git+https://github.com/sphinx-doc/sphinx.git
 extras =
     test: test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312}-test-sphinx{40,53,62,70,72,dev}{-cov}{-clocale}
+envlist = py{38,39,310,311,312}-test-sphinx{40,62,70,71,72,dev}{-cov}{-clocale}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 isolated_build = true
@@ -7,10 +7,10 @@ isolated_build = true
 [testenv]
 changedir = .tmp/{envname}
 deps =
-    sphinx40: sphinx==4.0.*
-    sphinx53: sphinx==5.3.*
+    sphinx40: sphinx==4.0.0
     sphinx62: sphinx==6.2.*
     sphinx70: sphinx==7.0.*
+    sphinx71: sphinx==7.1.*
     sphinx72: sphinx==7.2.*
     sphinxdev: git+https://github.com/sphinx-doc/sphinx.git
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312}-test-sphinx{40,53,62,70,71,72,dev}{-cov}{-clocale}
+envlist = py{38,39,310,311,312}-test-sphinx{_oldest,53,62,70,71,72,dev}{-cov}{-clocale}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 isolated_build = true
@@ -7,7 +7,7 @@ isolated_build = true
 [testenv]
 changedir = .tmp/{envname}
 deps =
-    sphinx40: sphinx==4.0.0
+    sphinx_oldest: sphinx==4.0.0
     sphinx53: sphinx==5.3.*
     sphinx62: sphinx==6.2.*
     sphinx70: sphinx==7.0.*


### PR DESCRIPTION
MNT: Drop Python 3.7

TST: Test against Sphinx 7.2 instead of 7.1

Fix #175