### PR TITLE
CI: update versions

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -69,11 +69,11 @@ jobs:
             toxenv: py311-test-sphinxdev
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install graphviz on Linux

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -46,7 +46,7 @@ jobs:
             python-version: '3.11'
             toxenv: py311-test-sphinx72-cov-clocale
           - os: ubuntu-latest
-            python-version: '3.12-dev'
+            python-version: '3.12'
             toxenv: py312-test-sphinxdev
 
           # MacOS X - just the stable and dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     if: ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.8
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
I noticed these out-of-dates versions while looking into reasons why we keep seeing failures in the OSX cron job. (They are unrelated to `sphinx-automodapi`, the job is always failing in the brew install parts, and sometimes passes after a restart or two.
