### PR TITLE
MAINT: adding sphinx 8.0.x to the testing matrix

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -47,12 +47,15 @@ jobs:
             toxenv: py311-test-sphinx72-cov-clocale
           - os: ubuntu-latest
             python-version: '3.12'
+            toxenv: py312-test-sphinx80
+          - os: ubuntu-latest
+            python-version: '3.12'
             toxenv: py312-test-sphinxdev
 
           # MacOS X - just the stable and dev
           - os: macos-latest
             python-version: '3.10'
-            toxenv: py310-test-sphinx72-clocale
+            toxenv: py310-test-sphinx80-clocale
           - os: macos-latest
             python-version: '3.11'
             toxenv: py311-test-sphinxdev
@@ -63,7 +66,7 @@ jobs:
             toxenv: py38-test-sphinx_oldest
           - os: windows-latest
             python-version: '3.10'
-            toxenv: py310-test-sphinx72
+            toxenv: py310-test-sphinx80
           - os: windows-latest
             python-version: '3.11'
             toxenv: py311-test-sphinxdev

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312}-test-sphinx{_oldest,53,62,70,71,72,dev}{-cov}{-clocale}
+envlist = py{38,39,310,311,312}-test-sphinx{_oldest,53,62,70,71,72,80,dev}{-cov}{-clocale}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 isolated_build = true
@@ -13,6 +13,7 @@ deps =
     sphinx70: sphinx==7.0.*
     sphinx71: sphinx==7.1.*
     sphinx72: sphinx==7.2.*
+    sphinx80: sphinx==8.0.*
     sphinxdev: git+https://github.com/sphinx-doc/sphinx.git
 extras =
     test: test


### PR DESCRIPTION
I don't expect any issues here, nevertheless, it's good to explicitly add the next major release to the testing matrix.