### PR TITLE
CI: install all test dependencies for test job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         cd ..
         python -m venv testenv
         testenv/bin/pip install pip -U
-        testenv/bin/pip install pytest cython sphinx-automodapi/dist/*.whl
+        testenv/bin/pip install sphinx-automodapi/dist/*.whl[test]
         testenv/bin/pytest sphinx-automodapi/sphinx_automodapi/tests
 
     - name: Publish distribution 📦 to PyPI


### PR DESCRIPTION
The release has run into this issue that some but not all of the test dependencies were manually listed, I rather switch to the config based approach.