### PR TITLE
Support for non-default dataclass fields (continuation of stale PR, https://github.com/astropy/sphinx-automodapi/pull/116)

### DIFF
--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -62,10 +62,17 @@ def type_object_attrgetter(obj, attr, *defargs):
 
     try:
         return getattr(obj, attr, *defargs)
-    except AttributeError:
+    except AttributeError as e:
         # for dataclasses, get the attribute from the __dataclass_fields__
         if dataclasses.is_dataclass(obj):
-            return obj.__dataclass_fields__[attr].name
+            if attr in obj.__dataclass_fields__:
+                return obj.__dataclass_fields__[attr].name
+            else:
+                # raise original AttributeError
+                raise e
+        else:
+            # raise original AttributeError
+            raise e
 
 
 def setup(app):

--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -1,6 +1,8 @@
 """
 Miscellaneous enhancements to help autodoc along.
 """
+import dataclasses
+
 from sphinx.ext.autodoc import AttributeDocumenter
 
 __all__ = []
@@ -58,7 +60,12 @@ def type_object_attrgetter(obj, attr, *defargs):
                 return base.__dict__[attr]
             break
 
-    return getattr(obj, attr, *defargs)
+    try:
+        return getattr(obj, attr, *defargs)
+    except AttributeError:
+        # for dataclasses, get the attribute from the __dataclass_fields__
+        if dataclasses.is_dataclass(obj):
+            return obj.__dataclass_fields__[attr].name
 
 
 def setup(app):

--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -62,17 +62,12 @@ def type_object_attrgetter(obj, attr, *defargs):
 
     try:
         return getattr(obj, attr, *defargs)
-    except AttributeError as e:
+    except AttributeError:
         # for dataclasses, get the attribute from the __dataclass_fields__
-        if dataclasses.is_dataclass(obj):
-            if attr in obj.__dataclass_fields__:
-                return obj.__dataclass_fields__[attr].name
-            else:
-                # raise original AttributeError
-                raise e
+        if dataclasses.is_dataclass(obj) and attr in obj.__dataclass_fields__:
+            return obj.__dataclass_fields__[attr].name
         else:
-            # raise original AttributeError
-            raise e
+            raise
 
 
 def setup(app):

--- a/sphinx_automodapi/autodoc_enhancements.py
+++ b/sphinx_automodapi/autodoc_enhancements.py
@@ -65,7 +65,7 @@ def type_object_attrgetter(obj, attr, *defargs):
     except AttributeError:
         # for dataclasses, get the attribute from the __dataclass_fields__
         if dataclasses.is_dataclass(obj) and attr in obj.__dataclass_fields__:
-            return obj.__dataclass_fields__[attr].name
+            return obj.__dataclass_fields__[attr].default
         else:
             raise
 

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -103,6 +103,7 @@ package. It accepts no options.
 import inspect
 import os
 import re
+import dataclasses
 
 import sphinx
 from docutils.parsers.rst.directives import flag
@@ -595,11 +596,22 @@ def generate_automodsumm_docs(lines, srcfn, app=None, suffix='.rst',
                 else:
                     names = getattr(obj, '__dict__').keys()
 
+                    # add dataclass_field names for dataclass classes
+                    if dataclasses.is_dataclass(obj):
+                        dataclass_fieldnames = getattr(obj, '__dataclass_fields__').keys()
+                        names = list(set(list(names) + list(dataclass_fieldnames)))
+
                 for name in names:
                     try:
                         documenter = get_documenter(app, safe_getattr(obj, name), obj)
                     except AttributeError:
-                        continue
+                        # for dataclasses try to get the attribute from the __dataclass_fields__
+                        if dataclasses.is_dataclass(obj):
+                            try:
+                                attr = obj.__dataclass_fields__[name]
+                                documenter = get_documenter(app, attr, obj)
+                            except KeyError:
+                                continue
                     if typ is None or documenter.objtype == typ:
                         items.append(name)
                     # elif typ == 'attribute' and documenter.objtype == 'property':

--- a/sphinx_automodapi/tests/test_autodoc_enhancements.py
+++ b/sphinx_automodapi/tests/test_autodoc_enhancements.py
@@ -56,5 +56,5 @@ def test_type_attrgetter_for_dataclass():
 
     with pytest.raises(AttributeError):
         getattr(MyDataclass, 'foo')
-    assert type_object_attrgetter(MyDataclass, 'foo') == 'foo'
+    assert type_object_attrgetter(MyDataclass, 'foo') == dataclasses.MISSING
     assert getattr(MyDataclass, 'bar') == 'bar value'

--- a/sphinx_automodapi/tests/test_autodoc_enhancements.py
+++ b/sphinx_automodapi/tests/test_autodoc_enhancements.py
@@ -41,3 +41,20 @@ def test_type_attrgetter():
 
     assert type_object_attrgetter(MyClass, 'susy', 'default') == 'default'
     assert type_object_attrgetter(MyClass, '__dict__') == MyClass.__dict__
+
+
+def test_type_attrgetter_for_dataclass():
+    """
+    This tests the attribute getter for non-default dataclass fields
+    """
+    import dataclasses
+
+    @dataclasses.dataclass
+    class MyDataclass:
+        foo: int
+        bar: str = "bar value"
+
+    with pytest.raises(AttributeError):
+        getattr(MyDataclass, 'foo')
+    assert type_object_attrgetter(MyDataclass, 'foo') == 'foo'
+    assert getattr(MyDataclass, 'bar') == 'bar value'


### PR DESCRIPTION
- Rebase https://github.com/astropy/sphinx-automodapi/pull/116 to fix #115
- Clean up exception handling and `if` statements as requested by @bsipocz (https://github.com/astropy/sphinx-automodapi/pull/116#discussion_r1166130661, https://github.com/astropy/sphinx-automodapi/pull/116#discussion_r1166131425).
- For fields that don't have a default value, report the default value as [`dataclasses.MISSING`](https://docs.python.org/3/library/dataclasses.html#dataclasses.MISSING) rather than incorrectly reporting the name of the field as the default value.