### PR TITLE
CI: adding Python 3.14 for testing

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -49,8 +49,8 @@ jobs:
             python-version: '3.12'
             toxenv: py312-test-sphinx81
           - os: ubuntu-latest
-            python-version: '3.13'
-            toxenv: py313-test-sphinx82
+            python-version: '3.14-dev'
+            toxenv: py314-test-sphinx82
           - os: ubuntu-latest
             python-version: '3.13'
             toxenv: py313-test-sphinxdev
@@ -60,19 +60,19 @@ jobs:
             python-version: '3.11'
             toxenv: py311-test-sphinx82-clocale
           - os: macos-latest
-            python-version: '3.13'
-            toxenv: py313-test-sphinxdev
+            python-version: '3.14-dev'
+            toxenv: py314-test-sphinxdev
 
           # Windows - just the oldest, stable, and dev
           - os: windows-latest
             python-version: 3.9
             toxenv: py39-test-sphinx_oldest
           - os: windows-latest
-            python-version: '3.12'
-            toxenv: py312-test-sphinx82
-          - os: windows-latest
             python-version: '3.13'
-            toxenv: py313-test-sphinxdev
+            toxenv: py313-test-sphinx82
+          - os: windows-latest
+            python-version: '3.14-dev'
+            toxenv: py314-test-sphinxdev
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313}-test-sphinx{_oldest,62,70,71,72,80,81,82,dev}{-cov}{-clocale}
+envlist = py{39,310,311,312,313,314}-test-sphinx{_oldest,62,70,71,72,80,81,82,dev}{-cov}{-clocale}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 isolated_build = true


### PR DESCRIPTION
The sphinxdev jobs will fail, but we need to double check if there is anything new mixed in there due to python 3.14