### PR TITLE
MAINT: removing python 3.9 support

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -28,14 +28,14 @@ jobs:
 
           # Linux - test different Sphinx versions
           - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-test-sphinx_oldest
+            python-version: '3.10'
+            toxenv: py310-test-sphinx_oldest
           - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-test-sphinx62
+            python-version: '3.10'
+            toxenv: py310-test-sphinx62
           - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-test-sphinx70
+            python-version: '3.10'
+            toxenv: py310-test-sphinx70
           - os: ubuntu-latest
             python-version: '3.10'
             toxenv: py310-test-sphinx71
@@ -55,8 +55,8 @@ jobs:
             python-version: '3.14'
             toxenv: py314-test-sphinx90
           - os: ubuntu-latest
-            python-version: '3.13'
-            toxenv: py313-test-sphinxdev
+            python-version: '3.14'
+            toxenv: py314-test-sphinxdev
 
           # MacOS X - just the stable and dev
           - os: macos-latest
@@ -68,8 +68,8 @@ jobs:
 
           # Windows - just the oldest, stable, and dev
           - os: windows-latest
-            python-version: 3.9
-            toxenv: py39-test-sphinx_oldest
+            python-version: '3.10'
+            toxenv: py310-test-sphinx_oldest
           - os: windows-latest
             python-version: '3.13'
             toxenv: py313-test-sphinx90

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes in sphinx-automodapi
 0.22.0 (unreleased)
 -------------------
 
-- No changes yet.
+- Minimum supported Python version is now 3.10. [#229]
 
 
 0.21.0 (2025-12-01)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 python_requires = >=3.10
 install_requires =
     packaging
-    sphinx>=4
+    sphinx>=5
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     packaging
     sphinx>=4
@@ -38,7 +38,7 @@ sphinx_automodapi = templates/*/*.rst
 sphinx_automodapi.tests = cases/*/*.*, cases/*/*/*.*, cases/*/*/*/*.*, cases/*/*/*/*/*.*, duplicated_warning/docs/*
 
 [tool:pytest]
-minversion = 4.6
+minversion = 7.0
 testpaths = sphinx_automodapi
 xfail_strict = true
 filterwarnings =

--- a/sphinx_automodapi/automodsumm.py
+++ b/sphinx_automodapi/automodsumm.py
@@ -112,7 +112,7 @@ from sphinx.util import logging
 from sphinx.ext.autosummary import Autosummary
 from sphinx.ext.inheritance_diagram import InheritanceDiagram, InheritanceGraph, try_import
 
-from .utils import find_mod_objs, cleanup_whitespace, SPHINX_LT_8_3
+from .utils import find_mod_objs, cleanup_whitespace, SPHINX_LT_9
 
 __all__ = ['Automoddiagram', 'Automodsumm', 'automodsumm_to_autosummary_lines',
            'generate_automodsumm_docs', 'process_automodsumm_generation']
@@ -219,7 +219,7 @@ class Automodsumm(Autosummary):
 
     def get_items(self, names):
 
-        if SPHINX_LT_8_3:
+        if SPHINX_LT_9:
             self.bridge.genopt.imported_members = True
 
         return Autosummary.get_items(self, names)

--- a/sphinx_automodapi/utils.py
+++ b/sphinx_automodapi/utils.py
@@ -12,7 +12,7 @@ __all__ = ['cleanup_whitespace',
            'find_mod_objs',
            'find_autosummary_in_lines_for_automodsumm']
 
-SPHINX_LT_8_3 = Version(sphinx.__version__) < Version("8.3.dev")
+SPHINX_LT_9 = Version(sphinx.__version__) < Version("9.0")
 
 # We use \n instead of os.linesep because even on Windows, the generated files
 # use \n as the newline character.
@@ -244,7 +244,7 @@ def get_object_type(app, obj, parent):
     another Python object (e.g. a module or a class) to which *obj*
     belongs to.
     """
-    if SPHINX_LT_8_3:
+    if SPHINX_LT_9:
         from sphinx.ext.autosummary import get_documenter
 
         documenter = get_documenter(app, obj, parent)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313,314}-test-sphinx{_oldest,62,70,71,72,80,81,82,90,dev}{-cov}{-clocale}
+envlist = py{310,311,312,313,314}-test-sphinx{_oldest,62,70,71,72,80,81,82,90,dev}{-cov}{-clocale}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 isolated_build = true


### PR DESCRIPTION
In practice this doesn't really mean much but to clean up the test matrix a little bit.