### PR TITLE
CI: temporarily upper pin for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
 
 [options.extras_require]
 test =
-    pytest
+    pytest<9.1
     pytest-cov
     cython
     coverage


### PR DESCRIPTION
This should patch up the CI for #239, I'm planning to do an actual fix once I'm back from holidays.